### PR TITLE
Pass secrets params when calling integrations.publish

### DIFF
--- a/packages/cli/src/publish.ts
+++ b/packages/cli/src/publish.ts
@@ -25,6 +25,7 @@ export async function publishIntegration(filePath: string): Promise<void> {
         scopes: manifest.scopes,
         categories: manifest.categories,
         configurations: manifest.configurations,
+        secrets: manifest.secrets,
         script,
     });
 


### PR DESCRIPTION
This PR aims to fix an small issue where the CLI doesn't include the secrets defined in the integration's manifest when calling the Integrations Publish API endpoint.