### PR TITLE
Fix PublishIntegration.integration reference in manifestSchema

### DIFF
--- a/packages/cli/src/manifest.ts
+++ b/packages/cli/src/manifest.ts
@@ -160,7 +160,7 @@ async function getManifestSchema() {
             organization: {
                 ...getAPIJsonSchemaFor(
                     openAPISpec,
-                    'components/schemas/requests/PublishIntegration/properties/organization'
+                    'components/schemas/RequestPublishIntegration/properties/organization'
                 ),
             },
         },


### PR DESCRIPTION
The `PublishIntegration` schema is exported as `RequestPublishIntegration` component but in `manifest.ts`, the `organization` field in the `manifestSchema` object references it as `components/schemas/requests/PublishIntegration/properties/organization`.

So when trying to publish an integration using the cli we get the following error during the manifest schema validation:
```
$ node ../../packages/cli/dist/cli.js publish gitbook-manifest.yaml
Could not find components/schemas/requests/RequestPublishIntegration/properties/organization (requests) in the API spec
Error: Could not find components/schemas/requests/RequestPublishIntegration/properties/organization (requests) in the API spec
    at getAPIJsonSchemaFor (/Users/steeve/dev/integrations/packages/cli/dist/cli.js:25439:13)
    at getManifestSchema (/Users/steeve/dev/integrations/packages/cli/dist/cli.js:25524:12)
    at async validateIntegrationManifest (/Users/steeve/dev/integrations/packages/cli/dist/cli.js:25473:27)
    at async publishIntegration (/Users/steeve/dev/integrations/packages/cli/dist/cli.js:25697:20)
    at async Command2.<anonymous> (/Users/steeve/dev/integrations/packages/cli/dist/cli.js:25764:3)
    at async Command2.parseAsync (/Users/steeve/dev/integrations/packages/cli/dist/cli.js:988:9)
```

This PR aims at fixing the reference so the schema uses the correct reference to the component field.