### PR TITLE
Pass missing context param for fetch event

### DIFF
--- a/packages/runtime-v8-stdlib/src/addEventListener.ts
+++ b/packages/runtime-v8-stdlib/src/addEventListener.ts
@@ -34,7 +34,7 @@ export function addEventListener(type, eventHandler) {
             const fetchEvent = new FetchEvent(event.type, event, callback);
 
             try {
-                const result = await eventHandler(fetchEvent);
+                const result = await eventHandler(fetchEvent, context);
 
                 if (result && !this.respondWithEntered) {
                     fetchEvent.respondWith(result);


### PR DESCRIPTION
Fixes a small bug related to `fetch` event which was not getting the `context` object as param in the callback. ([Reference](https://gitbook.slack.com/archives/C03LSHRBBBN/p1657269354541219)) 