### PR TITLE
Update Linear integration to use public assets and use ContentKitModal subtitle

### DIFF
--- a/integrations/linear/src/linear/operations.graphql
+++ b/integrations/linear/src/linear/operations.graphql
@@ -939,6 +939,7 @@ fragment Issue on Issue {
     assignee {
         id
         name
+        displayName
         avatarUrl
     }
     # The user who created the issue.


### PR DESCRIPTION
This PR aims to update the Linear integration to:

- Use the Linear icons uploaded to Cloudflare Pages
- Show contextual issue information in the issue preview modal using the `ContentKitModal` subtitle prop (https://github.com/GitbookIO/gitbook-x/pull/4182).

Part of https://github.com/GitbookIO/gitbook-x/issues/3966