### PR TITLE
Prevent autoupdate of cloudflared while creating tunnel

### DIFF
--- a/.changeset/rotten-books-unite.md
+++ b/.changeset/rotten-books-unite.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/cli': minor
+---
+
+Disable autoupdate of cloudflared binary

--- a/packages/cli/postinstall.js
+++ b/packages/cli/postinstall.js
@@ -139,4 +139,4 @@ function download(url, to, redirect = 0) {
  * Install the cloudflared binary inside the dist folder.
  * Locking the version to 2023.4.0 instead of latest to avoid breaking changes.
  */
-installCloudflared(path.join(__dirname, 'dist', 'cloudflared'), '2023.4.0');
+installCloudflared(path.join(__dirname, 'dist', 'cloudflared'), '2023.4.1');

--- a/packages/cli/src/tunnel.ts
+++ b/packages/cli/src/tunnel.ts
@@ -10,6 +10,7 @@ export function createDevTunnel(port: number): Promise<string> {
         let connectionsCount = 0;
         const cloudflared = spawn(path.join(__dirname, 'cloudflared'), [
             'tunnel',
+            '--no-autoupdate',
             '--url',
             `http://localhost:${port}`,
         ]);


### PR DESCRIPTION
cloudflared binaries by default will `autoupdate` which causes the create tunnel command to fail if it's using an older version. This PR ensures we don't autoupdate to prevent failure of the `dev` command