### PR TITLE
Accept application/json for OAuth access token response

### DIFF
--- a/.changeset/great-spoons-deny.md
+++ b/.changeset/great-spoons-deny.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/runtime': minor
+---
+
+Accept application/json by default for OAuth token response

--- a/packages/runtime/src/oauth.ts
+++ b/packages/runtime/src/oauth.ts
@@ -134,6 +134,7 @@ export function createOAuthHandler(
             const response = await fetch(config.accessTokenURL, {
                 method: 'POST',
                 headers: {
+                    Accept: 'application/json',
                     'Content-Type': 'application/x-www-form-urlencoded',
                 },
                 body: params.toString(),


### PR DESCRIPTION
### Context
While parsing Oauth response from GitHub, it's crashing because it's not a JSON by default. We need to tell these providers that we want only `JSON` response for the token  

![image](https://github.com/GitbookIO/integrations/assets/8937991/daee70e3-87e4-4119-b4be-3a4139a7484b)


<img width="782" alt="image" src="https://github.com/GitbookIO/integrations/assets/8937991/3a338bd5-7534-462f-95ec-42b2532d5bac">
