### PR TITLE
Increase usefulness of Slack integration

### DIFF
--- a/.changeset/silly-glasses-jump.md
+++ b/.changeset/silly-glasses-jump.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-slack': minor
+---
+
+When a space is updated, Slack messages will now include greater context such as the revision message and titles of updated pages

--- a/integrations/slack/src/index.ts
+++ b/integrations/slack/src/index.ts
@@ -27,6 +27,10 @@ const handleSpaceContentUpdated: EventCallback<
     }
 
     const { data: space } = await api.spaces.getSpaceById(event.spaceId);
+    const { data: revision } = await api.revisions.getRevisionById(event.spaceId, event.revisionId);
+
+    const revisionMessage = revision.git.message;
+    const pagesUpdatedInRevision = revision.pages.map((page) => page.title);
 
     await slackAPI(context, {
         method: 'POST',
@@ -40,7 +44,19 @@ const handleSpaceContentUpdated: EventCallback<
                         type: 'mrkdwn',
                         text: `Content of *<${space.urls.app}|${
                             space.title || 'Space'
-                        }>* has been updated`,
+                        }>* has been updated${
+                            revisionMessage.length > 0 ? `: *${revisionMessage}*` : ''
+                        }
+
+                        ${
+                            pagesUpdatedInRevision.length > 0
+                                ? `\n\nPages updated: \n ${pagesUpdatedInRevision.map(
+                                      (title) => `• ${title}\n`
+                                  )}`
+                                : ''
+                        }
+
+                        `,
                     },
                 },
             ],


### PR DESCRIPTION
Hi GitBook team 👋 

I love having Slack notifications when spaces get updated, but at the moment there's not a lot of context for the update:

> **GitBook** [App]
> Content of **Example Space Name** has been updated

I think we can do better. I've updated the Slack integration to include the message for the update (if it exists) and the titles of all updated pages.

> **GitBook** [App]
> Content of **Example Space Name** has been updated: **Add background info on xyz**
>
> Pages updated:
> * API - xyz
> * Concept - xyz

Unfortunately there wasn't really a way for me to test whether this works or not, so I've made the changes entirely based on what the types tell me should exist and the Slack API spec for section blocks. If you decide to merge this, it should probably be tested first 😆 

There may also be a better way of laying this content out, but I'm lazy and figured this was the fastest approach.

Let me know what you think! Thank you