### PR TITLE
Set allowFullScreen on Arcade webframes

### DIFF
--- a/integrations/arcade/src/index.tsx
+++ b/integrations/arcade/src/index.tsx
@@ -74,6 +74,7 @@ const embedBlock = createComponent<{
                         url: `https://demo.arcade.software/${flowId}?embed`,
                     }}
                     aspectRatio={aspectRatio}
+                    allowFullScreen={true}
                 />
             </block>
         );


### PR DESCRIPTION
This allows Arcade embeds to enter fullscreen mode. Needs the latest GitBook API update to be shipped first.