### PR TITLE
Make Formspree Integration more functional

### DIFF
--- a/integrations/formspree/gitbook-manifest.yaml
+++ b/integrations/formspree/gitbook-manifest.yaml
@@ -34,7 +34,7 @@ configurations:
                 type: boolean
                 title: Email
                 description: An email field for your form
-                default: false
+                default: true
             name:
                 type: boolean
                 title: Name

--- a/integrations/formspree/gitbook-manifest.yaml
+++ b/integrations/formspree/gitbook-manifest.yaml
@@ -24,16 +24,25 @@ blocks:
       title: Formspree
       description: My GitBook Integration
 configurations:
-    account:
-        properties:
-            formspree_id:
-                type: string
-                title: Formspree endpoint
-                description: The endpoint your formspree lives at.
     space:
         properties:
             formspree_id:
                 type: string
                 title: Formspree endpoint
                 description: The endpoint your formspree lives at.
+            email:
+                type: boolean
+                title: Email
+                description: An email field for your form
+                default: false
+            name:
+                type: boolean
+                title: Name
+                description: A name field for your form
+                default: false
+            message:
+                type: boolean
+                title: Message
+                description: A message field for your form
+                default: false
 secrets: {}

--- a/integrations/formspree/src/index.tsx
+++ b/integrations/formspree/src/index.tsx
@@ -7,11 +7,9 @@ type FormspreeContext = {
         spaceInstallation: {
             configuration: {
                 formspree_id: string;
-            };
-        };
-        installation: {
-            configuration: {
-                formspree_id: string;
+                email: string;
+                name: string;
+                message: string;
             };
         };
     };
@@ -25,15 +23,16 @@ const formspreeBlock = createComponent({
     componentId: 'formspree',
     initialState: {
         email: '',
+        name: '',
+        message: '',
         formSubmitted: false,
     },
     action: async (element, action: FormspreeAction, context: FormspreeContext) => {
         switch (action.action) {
             case 'submit':
                 handleSubmit(
-                    context.environment.spaceInstallation?.configuration.formspree_id ||
-                        context.environment.installation.configuration.formspree_id,
-                    element.state.email
+                    context.environment.spaceInstallation?.configuration.formspree_id,
+                    element.state
                 );
                 return {
                     state: {
@@ -42,13 +41,48 @@ const formspreeBlock = createComponent({
                 };
         }
     },
-    render: async (element, context) => {
+    render: async (element, context: FormspreeContext) => {
         return (
             <block>
-                <input
-                    label="Email"
-                    element={<textinput state="email" placeholder="Type your email" />}
-                />
+                <hstack>
+                    {/* Email */}
+                    {context.environment.spaceInstallation?.configuration.email ? (
+                        <box grow={1}>
+                            <input
+                                label="Email"
+                                element={<textinput state="email" placeholder="Your email" />}
+                            />
+                        </box>
+                    ) : null}
+
+                    {/* Name */}
+                    {context.environment.spaceInstallation?.configuration.name ? (
+                        <box grow={1}>
+                            <input
+                                label="Name"
+                                element={<textinput state="name" placeholder="Your name" />}
+                            />
+                        </box>
+                    ) : null}
+                </hstack>
+
+                <vstack>
+                    {/* Message */}
+                    {context.environment.spaceInstallation?.configuration.message ? (
+                        <box grow={2}>
+                            <input
+                                label="Message"
+                                element={
+                                    <textinput
+                                        state="message"
+                                        placeholder="Your message"
+                                        multiline={true}
+                                    />
+                                }
+                            />
+                        </box>
+                    ) : null}
+                </vstack>
 
                 <button
                     label={element.state.formSubmitted ? 'Submitted' : 'Submit'}

--- a/integrations/formspree/src/index.tsx
+++ b/integrations/formspree/src/index.tsx
@@ -30,10 +30,11 @@ const formspreeBlock = createComponent({
     action: async (element, action: FormspreeAction, context: FormspreeContext) => {
         switch (action.action) {
             case 'submit':
-                handleSubmit(
-                    context.environment.spaceInstallation?.configuration.formspree_id,
-                    element.state
-                );
+                handleSubmit(context.environment.spaceInstallation?.configuration.formspree_id, {
+                    email: element.state.email,
+                    name: element.state.name,
+                    message: element.state.message,
+                });
                 return {
                     state: {
                         formSubmitted: true,

--- a/integrations/formspree/src/utils.ts
+++ b/integrations/formspree/src/utils.ts
@@ -1,9 +1,11 @@
 // Handle errors better
 
-export async function handleSubmit(formspree_id, email) {
+export async function handleSubmit(formspree_id, body) {
+    const cleanedFormBody = await removeEmptyValues(body);
+
     fetch(formspree_id, {
         method: 'POST',
-        body: JSON.stringify({ email, form: 'GitBook Integration' }),
+        body: JSON.stringify({ cleanedFormBody, form: 'GitBook Integration' }),
         headers: {
             Accept: 'application/json',
         },
@@ -18,4 +20,16 @@ export async function handleSubmit(formspree_id, email) {
         .catch((error) => {
             console.error(error);
         });
+}
+
+// Clean data object being submitted
+export async function removeEmptyValues(object) {
+    for (const key in object) {
+        if (object.hasOwnProperty(key)) {
+            const value = object[key];
+            if (value === null || value === undefined || value === '') {
+                delete object[key];
+            }
+        }
+    }
 }

--- a/integrations/formspree/src/utils.ts
+++ b/integrations/formspree/src/utils.ts
@@ -5,7 +5,7 @@ export async function handleSubmit(formspree_id, body) {
 
     fetch(formspree_id, {
         method: 'POST',
-        body: JSON.stringify({ cleanedFormBody, form: 'GitBook Integration' }),
+        body: JSON.stringify({ data: cleanedFormBody, form: 'GitBook Integration' }),
         headers: {
             Accept: 'application/json',
         },
@@ -32,4 +32,5 @@ export async function removeEmptyValues(object) {
             }
         }
     }
+    return object;
 }


### PR DESCRIPTION
This PR adds the ability to choose different fields you would like to use in your Formspree instance. Limited right now to: 
- Name
- Email
- Message

Formspree will parse the incoming response based on the body submitted from this integration.