### PR TITLE
Add warnings to integrations

### DIFF
--- a/integrations/fathom/gitbook-manifest.yaml
+++ b/integrations/fathom/gitbook-manifest.yaml
@@ -9,6 +9,8 @@ externalLinks:
       url: https://www.gitbook.com/integrations/fathom
 visibility: public
 script: ./src/index.ts
+# The following scope(s) are available only to GitBook Staff
+# See https://developer.gitbook.com/integrations/configurations#scopes
 scopes:
     - space:script:inject
 contentSecurityPolicy:

--- a/integrations/googleanalytics/gitbook-manifest.yaml
+++ b/integrations/googleanalytics/gitbook-manifest.yaml
@@ -9,6 +9,8 @@ externalLinks:
       url: https://www.gitbook.com/integrations/googleanalytics
 visibility: public
 script: ./src/index.ts
+# The following scope(s) are available only to GitBook Staff
+# See https://developer.gitbook.com/integrations/configurations#scopes
 scopes:
     - space:script:inject
     - space:script:cookies

--- a/integrations/heap/gitbook-manifest.yaml
+++ b/integrations/heap/gitbook-manifest.yaml
@@ -10,6 +10,8 @@ externalLinks:
       url: https://www.gitbook.com/integrations/heap
 visibility: public
 script: ./src/index.ts
+# The following scope(s) are available only to GitBook Staff
+# See https://developer.gitbook.com/integrations/configurations#scopes
 scopes:
     - space:script:inject
 organization: d8f63b60-89ae-11e7-8574-5927d48c4877

--- a/integrations/hotjar/gitbook-manifest.yaml
+++ b/integrations/hotjar/gitbook-manifest.yaml
@@ -9,6 +9,8 @@ externalLinks:
       url: https://www.gitbook.com/integrations/hotjar
 visibility: public
 script: ./src/index.ts
+# The following scope(s) are available only to GitBook Staff
+# See https://developer.gitbook.com/integrations/configurations#scopes
 scopes:
     - space:script:inject
 organization: d8f63b60-89ae-11e7-8574-5927d48c4877

--- a/integrations/injectionTest/gitbook-manifest.yaml
+++ b/integrations/injectionTest/gitbook-manifest.yaml
@@ -4,6 +4,8 @@ icon: ./assets/icon.png
 description: Some test integration for injecting scripts
 visibility: private
 script: ./src/index.ts
+# The following scope(s) are available only to GitBook Staff
+# See https://developer.gitbook.com/integrations/configurations#scopes
 scopes:
     - space:script:inject
 summary: |

--- a/integrations/intercom/gitbook-manifest.yaml
+++ b/integrations/intercom/gitbook-manifest.yaml
@@ -9,6 +9,8 @@ externalLinks:
       url: https://www.gitbook.com/integrations/intercom
 visibility: public
 script: ./src/index.ts
+# The following scope(s) are available only to GitBook Staff
+# See https://developer.gitbook.com/integrations/configurations#scopes
 scopes:
     - space:script:inject
     - space:script:cookies

--- a/integrations/plausible/gitbook-manifest.yaml
+++ b/integrations/plausible/gitbook-manifest.yaml
@@ -9,6 +9,8 @@ externalLinks:
       url: https://www.gitbook.com/integrations/plausible
 visibility: public
 script: ./src/index.ts
+# The following scope(s) are available only to GitBook Staff
+# See https://developer.gitbook.com/integrations/configurations#scopes
 scopes:
     - space:script:inject
 contentSecurityPolicy:


### PR DESCRIPTION
Minor update to highlight the scopes not (yet) publicly available.