### PR TITLE
Update GitHub & GitLab Files integrations

### DIFF
--- a/integrations/github/src/github.ts
+++ b/integrations/github/src/github.ts
@@ -125,5 +125,5 @@ export const getGithubContent = async (url: string, context: GithubRuntimeContex
         }
     }
 
-    return content;
+    return [content, urlObject.fileName];
 };

--- a/integrations/github/src/index.tsx
+++ b/integrations/github/src/index.tsx
@@ -12,6 +12,7 @@ import {
 
 import { getGithubContent, GithubProps } from './github';
 import { GithubRuntimeContext } from './types';
+import { getFileExtension } from './utils';
 
 const embedBlock = createComponent<{ url?: string }, {}, {}, GithubRuntimeContext>({
     componentId: 'github-code-block',
@@ -34,7 +35,8 @@ const embedBlock = createComponent<{ url?: string }, {}, {}, GithubRuntimeContex
 
     async render(element, context) {
         const { url } = element.props as GithubProps;
-        const content = await getGithubContent(url, context);
+        const [content, fileName] = await getGithubContent(url, context);
+        const fileExtension = await getFileExtension(fileName);
 
         if (!content) {
             return (
@@ -59,7 +61,18 @@ const embedBlock = createComponent<{ url?: string }, {}, {}, GithubRuntimeContex
         }
 
         return (
-            <block>
+            <block
+                controls={[
+                    {
+                        label: 'Show link',
+                        icon: 'edit',
+                        onPress: {
+                            action: 'toggleTitleVisibility',
+                            props: {},
+                        },
+                    },
+                ]}
+            >
                 <card
                     title={url}
                     onPress={{
@@ -75,7 +88,13 @@ const embedBlock = createComponent<{ url?: string }, {}, {}, GithubRuntimeContex
                         />
                     }
                 >
-                    {content ? <codeblock content={content.toString()} lineNumbers={true} /> : null}
+                    {content ? (
+                        <codeblock
+                            content={content.toString()}
+                            lineNumbers={true}
+                            syntax={fileExtension}
+                        />
+                    ) : null}
                 </card>
             </block>
         );

--- a/integrations/github/src/index.tsx
+++ b/integrations/github/src/index.tsx
@@ -14,8 +14,16 @@ import { getGithubContent, GithubProps } from './github';
 import { GithubRuntimeContext } from './types';
 import { getFileExtension } from './utils';
 
-const embedBlock = createComponent<{ url?: string }, {}, {}, GithubRuntimeContext>({
+const embedBlock = createComponent<
+    { url?: string },
+    { visible: boolean },
+    {},
+    GithubRuntimeContext
+>({
     componentId: 'github-code-block',
+    initialState: {
+        visible: true,
+    },
 
     async action(element, action) {
         switch (action.action) {
@@ -27,6 +35,12 @@ const embedBlock = createComponent<{ url?: string }, {}, {}, GithubRuntimeContex
                         url,
                     },
                 };
+            }
+            case 'show': {
+                return { state: { visible: true } };
+            }
+            case 'hide': {
+                return { state: { visible: false } };
             }
         }
 
@@ -64,21 +78,29 @@ const embedBlock = createComponent<{ url?: string }, {}, {}, GithubRuntimeContex
             <block
                 controls={[
                     {
-                        label: 'Show link',
-                        icon: 'edit',
+                        label: 'Show title & link',
                         onPress: {
-                            action: 'toggleTitleVisibility',
-                            props: {},
+                            action: 'show',
+                        },
+                    },
+                    {
+                        label: 'Hide title & link',
+                        onPress: {
+                            action: 'hide',
                         },
                     },
                 ]}
             >
                 <card
-                    title={url}
-                    onPress={{
-                        action: '@ui.url.open',
-                        url,
-                    }}
+                    title={element.state.visible ? url : ''}
+                    onPress={
+                        element.state.visible
+                            ? {
+                                  action: '@ui.url.open',
+                                  url,
+                              }
+                            : { action: 'null' }
+                    }
                     icon={
                         <image
                             source={{

--- a/integrations/github/src/utils.ts
+++ b/integrations/github/src/utils.ts
@@ -1,0 +1,5 @@
+export const getFileExtension = async (fileName: string) => {
+    const re = /(?:\.([^.]+))?$/;
+
+    return re.exec(fileName)[1];
+};

--- a/integrations/gitlab/src/gitlab.ts
+++ b/integrations/gitlab/src/gitlab.ts
@@ -132,5 +132,5 @@ export const getGitlabContent = async (url: string, context: GitlabRuntimeContex
         }
     }
 
-    return content;
+    return [content, urlObject.filePath.split('#')[0]];
 };

--- a/integrations/gitlab/src/index.tsx
+++ b/integrations/gitlab/src/index.tsx
@@ -38,8 +38,8 @@ const gitlabCodeBlock = createComponent<
     async render(element, context) {
         const { url } = element.props as GitlabProps;
         const [content, filePath] = await getGitlabContent(url, context);
-        const fileExtension = await getFileExtension(filePath);=
-        
+        const fileExtension = await getFileExtension(filePath);
+
         if (!content) {
             return (
                 <block>

--- a/integrations/gitlab/src/index.tsx
+++ b/integrations/gitlab/src/index.tsx
@@ -2,6 +2,7 @@ import { createIntegration, createComponent, createOAuthHandler } from '@gitbook
 
 import { getGitlabContent, GitlabProps } from './gitlab';
 import { GitlabRuntimeContext } from './types';
+import { getFileExtension } from './utils';
 
 const gitlabCodeBlock = createComponent<
     { url?: string },
@@ -36,8 +37,9 @@ const gitlabCodeBlock = createComponent<
     },
     async render(element, context) {
         const { url } = element.props as GitlabProps;
-        const content = await getGitlabContent(url, context);
-
+        const [content, filePath] = await getGitlabContent(url, context);
+        const fileExtension = await getFileExtension(filePath);=
+        
         if (!content) {
             return (
                 <block>
@@ -109,7 +111,13 @@ const gitlabCodeBlock = createComponent<
                         />,
                     ]}
                 >
-                    {content ? <codeblock content={content.toString()} lineNumbers={true} /> : null}
+                    {content ? (
+                        <codeblock
+                            content={content.toString()}
+                            lineNumbers={true}
+                            syntax={fileExtension}
+                        />
+                    ) : null}
                 </card>
             </block>
         );

--- a/integrations/gitlab/src/index.tsx
+++ b/integrations/gitlab/src/index.tsx
@@ -3,8 +3,16 @@ import { createIntegration, createComponent, createOAuthHandler } from '@gitbook
 import { getGitlabContent, GitlabProps } from './gitlab';
 import { GitlabRuntimeContext } from './types';
 
-const gitlabCodeBlock = createComponent<{ url?: string }, {}, {}, GitlabRuntimeContext>({
+const gitlabCodeBlock = createComponent<
+    { url?: string },
+    { visible: boolean },
+    {},
+    GitlabRuntimeContext
+>({
     componentId: 'gitlab-code-block',
+    initialState: {
+        visible: true,
+    },
     async action(element, action) {
         switch (action.action) {
             case '@link.unfurl': {
@@ -15,6 +23,12 @@ const gitlabCodeBlock = createComponent<{ url?: string }, {}, {}, GitlabRuntimeC
                         url,
                     },
                 };
+            }
+            case 'show': {
+                return { state: { visible: true } };
+            }
+            case 'hide': {
+                return { state: { visible: false } };
             }
         }
 
@@ -47,13 +61,32 @@ const gitlabCodeBlock = createComponent<{ url?: string }, {}, {}, GitlabRuntimeC
         }
 
         return (
-            <block>
+            <block
+                controls={[
+                    {
+                        label: 'Show title & link',
+                        onPress: {
+                            action: 'show',
+                        },
+                    },
+                    {
+                        label: 'Hide title & link',
+                        onPress: {
+                            action: 'hide',
+                        },
+                    },
+                ]}
+            >
                 <card
-                    title={url}
-                    onPress={{
-                        action: '@ui.url.open',
-                        url,
-                    }}
+                    title={element.state.visible ? url : ''}
+                    onPress={
+                        element.state.visible
+                            ? {
+                                  action: '@ui.url.open',
+                                  url,
+                              }
+                            : { action: 'null' }
+                    }
                     icon={
                         <image
                             source={{

--- a/integrations/gitlab/src/utils.ts
+++ b/integrations/gitlab/src/utils.ts
@@ -1,0 +1,5 @@
+export const getFileExtension = async (fileName: string) => {
+    const re = /(?:\.([^.]+))?$/;
+
+    return re.exec(fileName)[1];
+};


### PR DESCRIPTION
This PR adds extra functionality to the GitHub Files and GitLab Files integrations. It closes https://github.com/GitbookIO/integrations/issues/178 and closes https://github.com/GitbookIO/integrations/issues/179

This PR:
- Adds auto-syntax highlighting to the code blocks for both GitHub and GitLab files when unfurled
- Adds the ability to hide the title and link from the context menu of each block