### PR TITLE
Update CLI script to create more accurate `package.json`

### DIFF
--- a/.changeset/dirty-hats-hope.md
+++ b/.changeset/dirty-hats-hope.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/cli': patch
+---
+
+Fix `gitbook new` script to generate correct (dev) deps

--- a/package-lock.json
+++ b/package-lock.json
@@ -5163,6 +5163,12 @@
             "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
             "dev": true
         },
+        "node_modules/@schemastore/package": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/@schemastore/package/-/package-0.0.10.tgz",
+            "integrity": "sha512-D3LxMCnkgsb4LO5sDKf6E+yahM2SqpEHmkqMPDSJis5Cy/j2MgWo/g/iq0lECK0mrPWfx3hqKm2ZJlqxwbRJQA==",
+            "dev": true
+        },
         "node_modules/@stoplight/json": {
             "version": "3.18.1",
             "license": "Apache-2.0",
@@ -13630,6 +13636,7 @@
             },
             "devDependencies": {
                 "@gitbook/eslint-config": "*",
+                "@schemastore/package": "^0.0.10",
                 "@types/node": "^17.0.33",
                 "@types/prompts": "^2.0.14",
                 "chokidar": "^3.5.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,7 @@
     },
     "devDependencies": {
         "@gitbook/eslint-config": "*",
+        "@schemastore/package": "^0.0.10",
         "@types/node": "^17.0.33",
         "@types/prompts": "^2.0.14",
         "chokidar": "^3.5.3",

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -1,3 +1,4 @@
+import { JSONSchemaForNPMPackageJsonFiles2 as PackageJSON } from '@schemastore/package';
 import { spawn } from 'child_process';
 import detent from 'dedent-js';
 import * as fs from 'fs';
@@ -136,32 +137,25 @@ export async function initializeProject(
 export async function extendPackageJson(dirPath: string, projectName: string): Promise<void> {
     const packageJsonPath = path.join(dirPath, 'package.json');
 
-    const packageJsonObject: {
-        name?: string;
-        private?: boolean;
-        scripts?: { [key: string]: string };
-        devDependencies?: { [key: string]: string };
-    } = {};
-
-    packageJsonObject.name = projectName;
-    packageJsonObject.private = true;
-    packageJsonObject.scripts = {
-        lint: 'eslint ./**/*.ts*',
-        typecheck: 'tsc --noEmit',
-
-        // TODO: this is GitBook-specific
-        'publish-integrations-staging': 'gitbook publish .',
+    const packageJsonObject: PackageJSON = {
+        name: projectName,
+        private: true,
+        scripts: {
+            lint: 'eslint --ext .js,.jsx,.ts,.tsx .',
+            typecheck: 'tsc --noEmit',
+            publish: 'gitbook publish .',
+        },
+        dependencies: {
+            '@gitbook/runtime': 'latest',
+        },
+        devDependencies: {
+            [packageJSON.name]: `^${packageJSON.version}`,
+            '@gitbook/eslint-config': 'latest',
+            '@gitbook/tsconfig': 'latest',
+        },
     };
 
-    packageJsonObject.devDependencies = {
-        ...(packageJsonObject.devDependencies || {}),
-        [packageJSON.name]: `^${packageJSON.version}`,
-        [`@gitbook/runtime`]: 'latest',
-        '@cloudflare/workers-types': 'latest',
-        '@gitbook/tsconfig': 'latest',
-    };
-
-    await fs.promises.writeFile(packageJsonPath, JSON.stringify(packageJsonObject, null, 2));
+    await fs.promises.writeFile(packageJsonPath, JSON.stringify(packageJsonObject, null, 4));
 }
 
 /**


### PR DESCRIPTION
- `@gitbook/runtime` is moved to `dependencies`
- `@gitbook/eslint-config` is added to `devDependencies`
- `@cloudflare/workers-types` is removed from `devDependencies`
- Remove the GitBook-specific `publish-integrations-staging` script, replace with `publish` script
- Use a library for typing of `package.json` schema, makes code a bit more readable