### PR TITLE
Switch command handler to routing patter to allow for url verification

### DIFF
--- a/integrations/slack/src/actions/queryLens.ts
+++ b/integrations/slack/src/actions/queryLens.ts
@@ -165,7 +165,7 @@ export async function queryLens({
         .oauth_credentials?.access_token;
 
     // strip a bot name if the user_id from the request is present in the query itself (specifically for a bot mention)
-  // @ts-ignore
+    // @ts-ignore
     const parsedQuery = stripMarkdown(stripBotName(text, authorization?.user_id));
 
     // async acknowledge the request to the end user early

--- a/integrations/slack/src/handlers/actions.ts
+++ b/integrations/slack/src/handlers/actions.ts
@@ -1,5 +1,5 @@
-import { type IQueryLens } from './actions/queryLens'; // eslint-disable-line import/no-internal-modules
-import { getActionNameAndType, parseActionPayload } from './utils';
+import { type IQueryLens } from '../actions';
+import { getActionNameAndType, parseActionPayload } from '../utils';
 
 /**
 

--- a/integrations/slack/src/handlers/commands.ts
+++ b/integrations/slack/src/handlers/commands.ts
@@ -1,6 +1,6 @@
 import { FetchEventCallback } from '@gitbook/runtime';
 
-import { SlackRuntimeContext } from './configuration';
+import { SlackRuntimeContext } from '../configuration';
 
 export interface SlashEvent {
     /** Slack App's unique ID */

--- a/integrations/slack/src/handlers/events.ts
+++ b/integrations/slack/src/handlers/events.ts
@@ -1,7 +1,7 @@
 import { FetchEventCallback } from '@gitbook/runtime';
 
-import { SlackRuntimeContext } from './configuration';
-import { parseEventPayload } from './utils';
+import { SlackRuntimeContext } from '../configuration';
+import { parseEventPayload } from '../utils';
 
 /**
  * Handle an event from Slack.

--- a/integrations/slack/src/handlers/index.ts
+++ b/integrations/slack/src/handlers/index.ts
@@ -1,2 +1,5 @@
 export * from './search';
 export * from './lens';
+export * from './actions';
+export * from './commands';
+export * from './events';

--- a/integrations/slack/src/handlers/lens.ts
+++ b/integrations/slack/src/handlers/lens.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@gitbook/runtime';
 
-import { queryLens } from '../actions/queryLens'; // eslint-disable-line
+import { queryLens } from '../actions/queryLens'; // eslint-disable-line import/no-internal-modules
 import type { SlashEvent } from '../commands';
 import { SlackRuntimeContext } from '../configuration';
 import { stripBotName } from '../utils';

--- a/integrations/slack/src/handlers/lens.ts
+++ b/integrations/slack/src/handlers/lens.ts
@@ -1,9 +1,9 @@
 import { Logger } from '@gitbook/runtime';
 
-import { queryLens } from '../actions/queryLens'; // eslint-disable-line import/no-internal-modules
-import type { SlashEvent } from '../commands';
+import { queryLens } from '../actions';
 import { SlackRuntimeContext } from '../configuration';
 import { stripBotName } from '../utils';
+import type { SlashEvent } from './commands';
 
 const logger = Logger('slack:api');
 

--- a/integrations/slack/src/handlers/lens.ts
+++ b/integrations/slack/src/handlers/lens.ts
@@ -1,8 +1,9 @@
 import { Logger } from '@gitbook/runtime';
 
-import { queryLens } from '../actions/queryLens';
+import { queryLens } from '../actions/queryLens'; // eslint-disable-line
 import type { SlashEvent } from '../commands';
 import { SlackRuntimeContext } from '../configuration';
+import { stripBotName } from '../utils';
 
 const logger = Logger('slack:api');
 
@@ -28,4 +29,37 @@ export async function queryLensSlashHandler(slashEvent: SlashEvent, context: Sla
         logger.error('Error calling queryLens. Perhasp no installation was found?');
         return {};
     }
+}
+
+/**
+ * Handle an Event request and route it to the GitBook Lens' query function.
+ */
+export async function queryLensEventHandler(eventPayload: any, context: SlackRuntimeContext) {
+    // pull out required params from the slashEvent for queryLens
+    const { type, text, bot_id, thread_ts, channel, user, team_id } = eventPayload.event;
+
+    // check for bot_id so that the bot doesn't trigger itself
+    if (['message', 'app_mention'].includes(type) && !bot_id) {
+        // strip out the bot-name in the mention and account for user mentions within the query
+        // @ts-ignore
+        const parsedQuery = stripBotName(text, eventPayload.authorizations[0]?.user_id);
+
+        // send to Lens
+        await queryLens({
+            teamId: team_id,
+            channelId: channel,
+            threadId: thread_ts,
+            userId: user,
+            messageType: 'permanent',
+            text: parsedQuery,
+            context,
+            // @ts-ignore
+            authorization: eventPayload.authorizations[0],
+        });
+    }
+
+    // Add custom header(s)
+    return new Response(null, {
+        status: 200,
+    });
 }

--- a/integrations/slack/src/router.ts
+++ b/integrations/slack/src/router.ts
@@ -2,11 +2,14 @@ import { Router } from 'itty-router';
 
 import { createOAuthHandler, FetchEventCallback } from '@gitbook/runtime';
 
-import { createSlackActionsHandler } from './actions';
-import { queryLens } from './actions/queryLens'; // eslint-disable-line import/no-internal-modules
-import { createSlackCommandsHandler } from './commands';
-import { createSlackEventsHandler } from './events';
-import { queryLensSlashHandler, queryLensEventHandler } from './handlers';
+import { queryLens } from './actions';
+import {
+    createSlackEventsHandler,
+    createSlackCommandsHandler,
+    createSlackActionsHandler,
+    queryLensSlashHandler,
+    queryLensEventHandler,
+} from './handlers';
 import { unfurlLink } from './links';
 import { verifySlackRequest, acknowledgeSlackRequest } from './middlewares';
 import { getChannelsPaginated } from './slack';

--- a/integrations/slack/src/router.ts
+++ b/integrations/slack/src/router.ts
@@ -6,7 +6,7 @@ import { createSlackActionsHandler } from './actions';
 import { queryLens } from './actions/queryLens'; // eslint-disable-line import/no-internal-modules
 import { createSlackCommandsHandler } from './commands';
 import { createSlackEventsHandler } from './events';
-import { queryLensSlashHandler } from './handlers';
+import { queryLensSlashHandler, queryLensEventHandler } from './handlers';
 import { unfurlLink } from './links';
 import { verifySlackRequest, acknowledgeSlackRequest } from './middlewares';
 import { getChannelsPaginated } from './slack';
@@ -68,12 +68,23 @@ export const handleFetchEvent: FetchEventCallback = async (request, context) => 
     );
 
     // event triggers, e.g app_mention
-    router.post('/events', verifySlackRequest, acknowledgeSlackRequest);
+    router.post(
+        '/events',
+        verifySlackRequest,
+        createSlackEventsHandler(
+            {
+                url_verification: async (event: { challenge: string }) => {
+                    return { challenge: event.challenge };
+                },
+            },
+            acknowledgeSlackRequest
+        )
+    );
 
     // shortcuts & interactivity
     router.post('/actions', verifySlackRequest, acknowledgeSlackRequest);
 
-    // /gitbook
+    // /gitbook slash commands
     router.post('/commands', verifySlackRequest, acknowledgeSlackRequest);
 
     router.post(
@@ -109,6 +120,8 @@ export const handleFetchEvent: FetchEventCallback = async (request, context) => 
         '/events_task',
         verifySlackRequest,
         createSlackEventsHandler({
+            message: queryLensEventHandler,
+            app_mention: queryLensEventHandler,
             link_shared: unfurlLink,
         })
     );


### PR DESCRIPTION
This changes the events handler over to the routing pattern used in other places. It allows us to handle the url_verify challenges from slack when you switch the events endpoint (which we need to do when we point it at different environments such as staging).