### PR TITLE
Pass more properties through during Integration Install

### DIFF
--- a/.changeset/lazy-cobras-fail.md
+++ b/.changeset/lazy-cobras-fail.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/runtime': patch
+---
+
+Fixes that externalIds and space_selection is passed to the install

--- a/packages/runtime/src/oauth.ts
+++ b/packages/runtime/src/oauth.ts
@@ -197,6 +197,11 @@ export function createOAuthHandler(
                         existing.configuration = spaceInstallation.configuration;
                     }
 
+                    // We need to make sure that properties outside of the credentials configuration are also passed when updating the installation (such as externalIds)
+                    const {
+                        configuration: credentialsConfiguration,
+                        ...credentialsMinusConfiguration
+                    } = credentials;
                     await api.integrations.updateIntegrationSpaceInstallation(
                         environment.integration.name,
                         state.installationId,
@@ -204,8 +209,9 @@ export function createOAuthHandler(
                         {
                             configuration: {
                                 ...existing.configuration,
-                                ...credentials.configuration,
+                                ...credentialsConfiguration,
                             },
+                            ...credentialsMinusConfiguration,
                         }
                     );
                 } else {
@@ -218,14 +224,21 @@ export function createOAuthHandler(
                         existing.configuration = installation.configuration;
                     }
 
+                    // We need to make sure that properties outside of the credentials configuration are also passed when updating the installation (such as externalIds)
+                    const {
+                        configuration: credentialsConfiguration,
+                        ...credentialsMinusConfiguration
+                    } = credentials;
+
                     await api.integrations.updateIntegrationInstallation(
                         environment.integration.name,
                         state.installationId,
                         {
                             configuration: {
                                 ...existing.configuration,
-                                ...credentials.configuration,
+                                ...credentialsConfiguration,
                             },
+                            ...credentialsMinusConfiguration,
                         }
                     );
                 }


### PR DESCRIPTION
This ensures that `externalIds` that are part of credentials (and not the configuration) are also sent down when updating the integration installation.

Additionally ensures that `space_selection` is passed onto the update as well.