### PR TITLE
Refactor Fetch out of Slack handlers, Minor visual updates

### DIFF
--- a/integrations/slack/src/actions/queryLens.ts
+++ b/integrations/slack/src/actions/queryLens.ts
@@ -22,6 +22,7 @@ import {
 } from '../ui/blocks'; // eslint-disable-line import/no-internal-modules
 import { stripBotName, stripMarkdown } from '../utils';
 
+// Recursively extracts all pages from a collection of RevisionPages
 function extractAllPages(rootPages: Array<RevisionPage>) {
     const result: Array<RevisionPage> = [];
 
@@ -39,6 +40,9 @@ function extractAllPages(rootPages: Array<RevisionPage>) {
     return result;
 }
 
+/*
+ * Pulls out the top related pages from page IDs returned from Lens and resolves them using a provided GitBook API client.
+ */
 async function getRelatedPages(params: {
     pages?: SearchAIAnswer['pages'];
     client: GitBookAPI;
@@ -50,7 +54,7 @@ async function getRelatedPages(params: {
         return [];
     }
 
-    // return top 3 pages (pages are ordered by score)
+    // return top 3 pages (pages are ordered by score by default)
     const sourcePages = pages.slice(0, 3);
 
     // collect all spaces from page results (and de-dupe)
@@ -124,6 +128,9 @@ export interface IQueryLens {
     authorization?: string;
 }
 
+/*
+ * Gets an API client and tied to installation that the Slack installation was installed on. This also returns the installation associated.
+ */
 async function getInstallationApiClient(api, externalId: string) {
     const {
         data: { items: installations },
@@ -133,7 +140,7 @@ async function getInstallationApiClient(api, externalId: string) {
         // we need to pass installation.target.organization
     });
 
-    // won't work for multiple installations accross orgs and same slack team
+    // won't work for multiple installations across orgs and same slack team
     const installation = installations[0];
     if (!installation) {
         return {};
@@ -145,6 +152,9 @@ async function getInstallationApiClient(api, externalId: string) {
     return { client: installationApiClient, installation };
 }
 
+/*
+ * Queries GitBook Lens via the GitBook API and posts the answer in the form of Slack UI Blocks back to the original channel/conversation/thread.
+ */
 export async function queryLens({
     channelId,
     teamId,

--- a/integrations/slack/src/handlers/commands.ts
+++ b/integrations/slack/src/handlers/commands.ts
@@ -50,10 +50,8 @@ export function createSlackCommandsHandler(handlers: {
             });
         }
 
-        await handler(slashEvent, context);
+        const handlerPromise = handler(slashEvent, context);
 
-        return new Response(null, {
-            status: 200,
-        });
+        context.waitUntil(handlerPromise);
     };
 }

--- a/integrations/slack/src/handlers/events.ts
+++ b/integrations/slack/src/handlers/events.ts
@@ -36,6 +36,8 @@ export function createSlackEventsHandler(
             });
         }
 
-        return handler(eventPayload, context);
+        const handlerPromise = handler(eventPayload, context);
+
+        context.waitUntil(handlerPromise);
     };
 }

--- a/integrations/slack/src/handlers/lens.ts
+++ b/integrations/slack/src/handlers/lens.ts
@@ -26,7 +26,7 @@ export async function queryLensSlashHandler(slashEvent: SlashEvent, context: Sla
         });
     } catch (e) {
         // Error state. Probably no installation was found
-        logger.error('Error calling queryLens. Perhasp no installation was found?');
+        logger.error('Error calling queryLens. Perhaps no installation was found?');
         return {};
     }
 }
@@ -36,7 +36,7 @@ export async function queryLensSlashHandler(slashEvent: SlashEvent, context: Sla
  */
 export async function queryLensEventHandler(eventPayload: any, context: SlackRuntimeContext) {
     // pull out required params from the slashEvent for queryLens
-    const { type, text, bot_id, thread_ts, channel, user, team_id } = eventPayload.event;
+    const { type, text, bot_id, thread_ts, channel, user, team } = eventPayload.event;
 
     // check for bot_id so that the bot doesn't trigger itself
     if (['message', 'app_mention'].includes(type) && !bot_id) {
@@ -46,7 +46,7 @@ export async function queryLensEventHandler(eventPayload: any, context: SlackRun
 
         // send to Lens
         await queryLens({
-            teamId: team_id,
+            teamId: team,
             channelId: channel,
             threadId: thread_ts,
             userId: user,

--- a/integrations/slack/src/links.ts
+++ b/integrations/slack/src/links.ts
@@ -27,6 +27,11 @@ interface LinkSharedSlackEvent {
 export async function unfurlLink(event: LinkSharedSlackEvent, context: SlackRuntimeContext) {
     const { api } = context;
 
+    // if the link was posted by a bot, ignore this request
+    if (event.event?.is_bot_user_member) {
+        return {};
+    }
+
     // Lookup the concerned installations
     const {
         data: { items: installations },

--- a/integrations/slack/src/middlewares.ts
+++ b/integrations/slack/src/middlewares.ts
@@ -72,19 +72,7 @@ export function acknowledgeQuery({
  * We acknowledge the slack request immediately to avoid failures
  * and "queue" the actual task to be executed in a subsequent request.
  */
-export async function acknowledgeSlackRequest(req: Request, context: SlackRuntimeContext) {
-    const fetchPromise = fetch(`${req.url}_task`, {
-        method: 'POST',
-        body: await req.text(),
-        headers: {
-            'content-type': req.headers.get('content-type'),
-            'x-slack-signature': req.headers.get('x-slack-signature'),
-            'x-slack-request-timestamp': req.headers.get('x-slack-request-timestamp'),
-        },
-    });
-
-    context.waitUntil(fetchPromise);
-
+export async function acknowledgeSlackRequest() {
     return new Response(null, {
         status: 200,
     });

--- a/integrations/slack/src/ui/blocks/index.ts
+++ b/integrations/slack/src/ui/blocks/index.ts
@@ -124,7 +124,7 @@ export function ShareTools(text: string) {
                     type: 'button',
                     text: {
                         type: 'plain_text',
-                        text: 'Send',
+                        text: 'Share',
                         emoji: true,
                     },
                     value: text,


### PR DESCRIPTION
This change factors out the proxying of slack events, commands, and actions that was dispatching a fetch and immediately returning. 

This was causing some issues in prod/staging due to limitations in Cloudflare workers unable to call other workers in the same zone (in our dev environments this is not happening as it is dispatched through another function outside of Cloudflare). This removes the fetch entirely opting to rely on the FetchEvent.waitUntil to immediately return and keep the worker alive until the actual process of querying the API is finished.

Additionally, a small change to the name of the "sharing" button in the slack block UI was changed from "Send" to "Share" and links are no longer unfurled if they were posted by a bot.

- refactor the fetch in favor of waitUntil to avoid worker to worker call
- don't unfurl if the bot added the links
- use share instead of send
