### PR TITLE
Allow Slash Events in DMs

### DIFF
--- a/integrations/slack/src/actions/queryLens.ts
+++ b/integrations/slack/src/actions/queryLens.ts
@@ -249,6 +249,8 @@ export async function queryLens({
                     user: userId,
 
                     ...(threadId ? { thread_ts: threadId } : {}),
+
+                    replace_original: 'false',
                 },
             };
         } else {
@@ -262,6 +264,9 @@ export async function queryLens({
                     blocks,
                     user: userId,
                     unfurl_links: false,
+
+                    response_type: 'in_channel',
+                    replace_original: 'false',
                 },
             };
         }
@@ -292,6 +297,8 @@ export async function queryLens({
                 ],
 
                 user: userId,
+                response_type: 'in_channel',
+                replace_original: 'false',
             },
         };
 

--- a/integrations/slack/src/handlers/actions.ts
+++ b/integrations/slack/src/handlers/actions.ts
@@ -15,12 +15,16 @@ export function createSlackActionsHandler(
     return async (request, context) => {
         const actionPayload = await parseActionPayload(request);
 
-        const { actions, container, channel, team, user } = actionPayload;
+        const { actions, container, channel, channel_name, team, user, response_url } =
+            actionPayload;
 
         // go through all actions sent and call the action from './actions/index.ts'
         if (actions?.length > 0) {
             const action = actions[0];
             const { actionName, actionPostType } = getActionNameAndType(action.action_id);
+
+            const dontUseResponseUrl =
+                channel_name !== 'directmessage' && actionPostType !== 'ephemeral';
 
             // dispatch the action to an appropriate action function
             if (actionName === 'queryLens') {
@@ -35,6 +39,9 @@ export function createSlackActionsHandler(
                     // pass user if exists
                     ...(user.id ? { userId: user.id } : {}),
 
+                    // if we have a response_url, we can reply safely using that
+                    responseUrl: dontUseResponseUrl ? null : response_url,
+                    // responseUrl: response_url,
                     context,
                 };
 

--- a/integrations/slack/src/handlers/actions.ts
+++ b/integrations/slack/src/handlers/actions.ts
@@ -43,7 +43,7 @@ export function createSlackActionsHandler(
                     ...(user.id ? { userId: user.id } : {}),
 
                     // if we have a response_url, we can reply safely using that
-                    responseUrl: dontUseResponseUrl ? null : response_url,
+                    responseUrl: dontUseResponseUrl ? undefined : response_url,
                     context,
                 };
 

--- a/integrations/slack/src/handlers/actions.ts
+++ b/integrations/slack/src/handlers/actions.ts
@@ -23,6 +23,9 @@ export function createSlackActionsHandler(
             const action = actions[0];
             const { actionName, actionPostType } = getActionNameAndType(action.action_id);
 
+            // TODO: using the response_url does not allow you to change the messageType (ie. ephemeral vs permanent).
+            // if we are in a channel and using an action where we are trying to post into the channel via, share, we
+            // need to skip using the response_url
             const dontUseResponseUrl =
                 channel_name !== 'directmessage' && actionPostType !== 'ephemeral';
 
@@ -41,7 +44,6 @@ export function createSlackActionsHandler(
 
                     // if we have a response_url, we can reply safely using that
                     responseUrl: dontUseResponseUrl ? null : response_url,
-                    // responseUrl: response_url,
                     context,
                 };
 

--- a/integrations/slack/src/handlers/lens.ts
+++ b/integrations/slack/src/handlers/lens.ts
@@ -12,11 +12,14 @@ const logger = Logger('slack:api');
  */
 export async function queryLensSlashHandler(slashEvent: SlashEvent, context: SlackRuntimeContext) {
     // pull out required params from the slashEvent for queryLens
-    const { team_id, channel_id, thread_ts, user_id, text } = slashEvent;
+    const { team_id, channel_id, thread_ts, user_id, text, channel_name, response_url } =
+        slashEvent;
 
     try {
         return queryLens({
             channelId: channel_id,
+            channelName: channel_name,
+            responseUrl: response_url,
             teamId: team_id,
             threadId: thread_ts,
             text,

--- a/integrations/slack/src/middlewares.ts
+++ b/integrations/slack/src/middlewares.ts
@@ -41,6 +41,7 @@ export function acknowledgeQuery({
     text,
     userId,
     channelId,
+    responseUrl,
     threadId,
     accessToken,
     messageType = 'ephemeral',
@@ -55,6 +56,7 @@ export function acknowledgeQuery({
         {
             method: 'POST',
             path: slackMessageTypes[messageType], // probably alwasy ephemeral? or otherwise have replies in same thread
+            responseUrl,
             payload: {
                 channel: channelId,
                 text: `_Asking: ${stripMarkdown(text)}_`,

--- a/integrations/slack/src/slack.ts
+++ b/integrations/slack/src/slack.ts
@@ -65,6 +65,7 @@ export async function slackAPI(
     request: {
         method: string;
         path: string;
+        responseUrl?: string;
         payload?: { [key: string]: any };
     },
     options: {
@@ -82,7 +83,9 @@ export async function slackAPI(
         throw new Error('No authentication token provided');
     }
 
-    const url = new URL(`https://slack.com/api/${request.path}`);
+    const url = request.responseUrl
+        ? new URL(request.responseUrl)
+        : new URL(`https://slack.com/api/${request.path}`);
 
     let body;
     const headers: {


### PR DESCRIPTION
This switches most replies to use the response_url as it is more consistent across different messaging contexts. This enables the ability to use the slack commands from within a DM for instance which was previously not possible.
It does introduce some complexity as we don't always want to use response_url in every context and that is commented for now so we can get it pushed out.

- ensure that we are sharing without it being ephemeral
- add comment for odd boolean
