### PR TITLE
Mermaid - Add securityLevel loose to open links in a new tab

### DIFF
--- a/integrations/mermaid/src/index.tsx
+++ b/integrations/mermaid/src/index.tsx
@@ -70,7 +70,7 @@ export default createIntegration({
                 <body>
                     <script type="module">
                         import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
-                        mermaid.initialize({ startOnLoad: false , securityLevel: 'loose' });
+                        mermaid.initialize({ startOnLoad: false, securityLevel: 'loose' });
 
                         function renderDiagram(content) {
                             mermaid.render('output', content).then(({ svg: svgGraph }) => {

--- a/integrations/mermaid/src/index.tsx
+++ b/integrations/mermaid/src/index.tsx
@@ -70,7 +70,7 @@ export default createIntegration({
                 <body>
                     <script type="module">
                         import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
-                        mermaid.initialize({ startOnLoad: false });
+                        mermaid.initialize({ startOnLoad: false , securityLevel: 'loose' });
 
                         function renderDiagram(content) {
                             mermaid.render('output', content).then(({ svg: svgGraph }) => {


### PR DESCRIPTION
New links can be opened in a new tab based on the [Mermaid documentation](https://mermaid.js.org/syntax/flowchart.html#interaction). This requires the security level to be set to loose.

This PR adds the security level loose to allow for links to be opened in a new tab.