### PR TITLE
Enable unfurls again, ensure we arent allow unfurls on bot messages

### DIFF
--- a/integrations/slack/src/actions/queryLens.ts
+++ b/integrations/slack/src/actions/queryLens.ts
@@ -229,6 +229,7 @@ export async function queryLens({
                     ...(threadId ? { thread_ts: threadId } : {}),
 
                     replace_original: 'false',
+                    unfurl_links: false,
                 },
             };
         } else {
@@ -277,6 +278,7 @@ export async function queryLens({
                 user: userId,
                 ...(messageType === 'permanent' ? { response_type: 'in_channel' } : {}),
                 replace_original: 'false',
+                unfurl_links: false,
             },
         };
 

--- a/integrations/slack/src/links.ts
+++ b/integrations/slack/src/links.ts
@@ -27,11 +27,6 @@ interface LinkSharedSlackEvent {
 export async function unfurlLink(event: LinkSharedSlackEvent, context: SlackRuntimeContext) {
     const { api } = context;
 
-    // if the link was posted by a bot, ignore this request
-    if (event.event?.is_bot_user_member) {
-        return {};
-    }
-
     // Lookup the concerned installations
     const {
         data: { items: installations },


### PR DESCRIPTION
This enabled unfurls of the private links for the Slack integration. It does not solve the issue of our bot triggering unfurls as well. This should be handled by Slack but something is not working there. 

This fixes a regression.