### PR TITLE
Support snippets in citations on slackbot

### DIFF
--- a/.changeset/sixty-tigers-search.md
+++ b/.changeset/sixty-tigers-search.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-slack': minor
+---
+
+Adds support for snippets to be displayed in answers from GitBook AI

--- a/integrations/slack/gitbook-manifest.yaml
+++ b/integrations/slack/gitbook-manifest.yaml
@@ -20,6 +20,7 @@ scopes:
     - space:content:read
     - space:metadata:read
     - capture:write
+    - snippets:read
 summary: |
     # Overview
     With the GitBook Slack integration, your teams have instant access to your GitBook knowledge base, and can get AI-summarized answers about your content. Plus, if you solve a problem in a thread, you can ask GitBook AI to summarize it into useable documentation.

--- a/integrations/slack/src/actions/queryLens.ts
+++ b/integrations/slack/src/actions/queryLens.ts
@@ -125,7 +125,7 @@ async function getRelatedSources(params: {
     const getResolvedSnippet = async (
         source: SearchAIAnswerSource & { type: 'snippet' | 'capture' }
     ): Promise<RelatedSource> => {
-        const snippetRequest = await client.orgs.getCapture(organization, source.captureId);
+        const snippetRequest = await client.orgs.getSnippet(organization, source.captureId);
         const snippet = snippetRequest.data;
 
         const sourceUrl = snippet.urls.app;

--- a/integrations/slack/src/actions/queryLens.ts
+++ b/integrations/slack/src/actions/queryLens.ts
@@ -14,7 +14,7 @@ import {
 } from '../configuration';
 import { acknowledgeQuery } from '../middlewares';
 import { slackAPI } from '../slack';
-import { PagesBlock, QueryDisplayBlock, ShareTools, decodeSlackEscapeChars, Spacer } from '../ui';
+import { QueryDisplayBlock, ShareTools, decodeSlackEscapeChars, Spacer, SourcesBlock } from '../ui';
 import { getInstallationApiClient, stripBotName, stripMarkdown } from '../utils';
 
 // Recursively extracts all pages from a collection of RevisionPages
@@ -126,7 +126,6 @@ async function getRelatedPages(params: {
         return accum;
     }, [] as RelatedSource[]);
 
-    // { type: 'capture', captureId: '72', source: 'slack' }
     // extract all related pages from the Revisions along with the related public URL
     const relatedSources: Array<RelatedSource> = sourcePages.reduce((accum, source) => {
         switch (source.type) {
@@ -254,7 +253,7 @@ export async function queryLens({
             {
                 type: 'divider',
             },
-            ...PagesBlock({
+            ...SourcesBlock({
                 title: 'Sources',
                 items: relatedPages,
             }),

--- a/integrations/slack/src/actions/queryLens.ts
+++ b/integrations/slack/src/actions/queryLens.ts
@@ -20,7 +20,7 @@ import { getInstallationApiClient, stripBotName, stripMarkdown } from '../utils'
 export type RelatedSource = {
     id: string;
     sourceUrl: string;
-    page: { path: string; title: string };
+    page: { path?: string; title: string };
 };
 
 export interface IQueryLens {
@@ -117,7 +117,7 @@ async function getRelatedSources(params: {
             return {
                 id: page.page,
                 sourceUrl,
-                page: revisionPage,
+                page: { path: revisionPage.path, title: revisionPage.title },
             } as RelatedSource;
         }
     };
@@ -133,7 +133,7 @@ async function getRelatedSources(params: {
         return {
             id: snippet.id,
             sourceUrl,
-            page: { path: '', title: snippet.title },
+            page: { title: snippet.title },
         };
     };
 

--- a/integrations/slack/src/actions/queryLens.ts
+++ b/integrations/slack/src/actions/queryLens.ts
@@ -100,23 +100,16 @@ async function getRelatedPages(params: {
     const getResolvedSnippet = async (
         source: SearchAIAnswerSource & { type: 'snippet' | 'capture' }
     ): Promise<RelatedSource> => {
-        try {
-            const snippetRequest = await client.orgs.getCapture(organization, source.captureId);
-            const snippet = snippetRequest.data;
-            console.log('URLS', snippet.urls);
+        const snippetRequest = await client.orgs.getCapture(organization, source.captureId);
+        const snippet = snippetRequest.data;
 
-            const publicUrl = `https://app.gitbook.com/o/${organization}`; // TODO replace with actual org public url
-            const sourceUrl = `${publicUrl}/snippets/${snippet.id}`;
+        const sourceUrl = snippet.urls.app;
 
-            return {
-                id: snippet.id,
-                sourceUrl,
-                page: { path: '', title: snippet.title },
-            };
-        } catch (e) {
-            console.log(e);
-            throw e;
-        }
+        return {
+            id: snippet.id,
+            sourceUrl,
+            page: { path: '', title: snippet.title },
+        };
     };
 
     const resolvedSnippetsPromises = await Promise.allSettled(

--- a/integrations/slack/src/ui/blocks/index.ts
+++ b/integrations/slack/src/ui/blocks/index.ts
@@ -1,4 +1,4 @@
-import { RevisionPage } from '@gitbook/api';
+import { RevisionPage, SearchAIAnswer } from '@gitbook/api';
 
 // Slack only encodes these specific characters so we need to remove them in the output (specifically used for inputs to slack)
 export function decodeSlackEscapeChars(text: string) {
@@ -23,7 +23,7 @@ export function PageBlock(page: RevisionPage, sourceUrl: string) {
 
 export function PagesBlock(params: {
     title?: string;
-    items: Array<{ sourceUrl: string; page: RevisionPage }>;
+    items: Array<{ sourceUrl: string; page: SearchAIAnswer }>;
 }) {
     const { title, items } = params;
 

--- a/integrations/slack/src/ui/blocks/index.ts
+++ b/integrations/slack/src/ui/blocks/index.ts
@@ -1,5 +1,4 @@
-import { RevisionPage, SearchAIAnswer } from '@gitbook/api';
-import { RelatedSource } from '../../actions/queryLens';
+import { RelatedSource } from '../../actions/';
 
 // Slack only encodes these specific characters so we need to remove them in the output (specifically used for inputs to slack)
 export function decodeSlackEscapeChars(text: string) {
@@ -12,21 +11,20 @@ export function decodeSlackEscapeChars(text: string) {
     }, text);
 }
 
-export function PageBlock(page: { path: string; title: string }, sourceUrl: string) {
-    // TODO: note for review. is this the best way to do this?
-    const nonRevisionPublicUrl = sourceUrl.split('~/')[0];
-    const url = `${nonRevisionPublicUrl}${page.path}`;
+export function SourceBlock(source: RelatedSource) {
+    const nonRevisionPublicUrl = source.sourceUrl.split('~/')[0];
+    const url = `${nonRevisionPublicUrl}${source.page.path || ''}`;
     return {
         type: 'mrkdwn',
-        text: `*<${url}|:spiral_note_pad: ${page.title}>*`,
+        text: `*<${url}|:spiral_note_pad: ${source.page.title}>*`,
     };
 }
 
-export function PagesBlock(params: { title?: string; items: Array<RelatedSource> }) {
+export function SourcesBlock(params: { title?: string; items: Array<RelatedSource> }) {
     const { title, items } = params;
 
     const blocks = items.reduce<Array<any>>((acc, pageData) => {
-        const pageResultBlock = PageBlock(pageData.page, pageData.sourceUrl);
+        const pageResultBlock = SourceBlock(pageData);
         acc.push(pageResultBlock);
 
         return acc;

--- a/integrations/slack/src/ui/blocks/index.ts
+++ b/integrations/slack/src/ui/blocks/index.ts
@@ -1,4 +1,5 @@
 import { RevisionPage, SearchAIAnswer } from '@gitbook/api';
+import { RelatedSource } from '../../actions/queryLens';
 
 // Slack only encodes these specific characters so we need to remove them in the output (specifically used for inputs to slack)
 export function decodeSlackEscapeChars(text: string) {
@@ -11,7 +12,7 @@ export function decodeSlackEscapeChars(text: string) {
     }, text);
 }
 
-export function PageBlock(page: RevisionPage, sourceUrl: string) {
+export function PageBlock(page: { path: string; title: string }, sourceUrl: string) {
     // TODO: note for review. is this the best way to do this?
     const nonRevisionPublicUrl = sourceUrl.split('~/')[0];
     const url = `${nonRevisionPublicUrl}${page.path}`;
@@ -21,10 +22,7 @@ export function PageBlock(page: RevisionPage, sourceUrl: string) {
     };
 }
 
-export function PagesBlock(params: {
-    title?: string;
-    items: Array<{ sourceUrl: string; page: SearchAIAnswer }>;
-}) {
+export function PagesBlock(params: { title?: string; items: Array<RelatedSource> }) {
     const { title, items } = params;
 
     const blocks = items.reduce<Array<any>>((acc, pageData) => {


### PR DESCRIPTION
This adds support for Snippets being displayed in the Slack AI answers along with links to the source snippet. It also adds in permissions needed to retrieve those snippets.