### PR TITLE
Slack notification, use semantic changes

### DIFF
--- a/.changeset/moody-ants-fetch.md
+++ b/.changeset/moody-ants-fetch.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-slack': minor
+---
+
+Notiy of space updates with a more detailed notification

--- a/.changeset/moody-ants-fetch.md
+++ b/.changeset/moody-ants-fetch.md
@@ -2,4 +2,4 @@
 '@gitbook/integration-slack': minor
 ---
 
-Notiy of space updates with a more detailed notification
+Notify of space updates with a more detailed notification

--- a/integrations/slack/src/index.ts
+++ b/integrations/slack/src/index.ts
@@ -48,7 +48,7 @@ const handleSpaceContentUpdated: EventCallback<
      *
      *    Content of *Space* has been updated.
      *
-     *    Summary of Changes:
+     *    Summary of changes:
      *    • New pages: Page1, Page2
      *    • Modified pages: Page3
      *    • Deleted pages: Page4, Page5
@@ -109,7 +109,7 @@ const handleSpaceContentUpdated: EventCallback<
         editedFiles.length > 0 ||
         deletedFiles.length > 0
     ) {
-        notificationText += '\n\nSummary of Changes:';
+        notificationText += '\n\nSummary of changes:';
 
         if (createdPages.length > 0) {
             notificationText += `\n• New pages: ${createdPages.join(', ')}`;

--- a/integrations/slack/src/index.ts
+++ b/integrations/slack/src/index.ts
@@ -1,3 +1,4 @@
+import { RevisionSemanticChangeType } from '@gitbook/api';
 import { createIntegration, EventCallback } from '@gitbook/runtime';
 
 import { SlackRuntimeContext } from './configuration';
@@ -26,7 +27,114 @@ const handleSpaceContentUpdated: EventCallback<
         return;
     }
 
+    const { data: semanticChanges } = await api.spaces.getRevisionSemanticChanges(
+        event.spaceId,
+        event.revisionId,
+        {
+            // Ignore git metadata and custom field changes
+            metadata: false,
+        }
+    );
+
+    if (semanticChanges.changes.length === 0) {
+        // No changes to notify about
+        return;
+    }
+
     const { data: space } = await api.spaces.getSpaceById(event.spaceId);
+
+    /*
+     * Build a notification that looks something like this:
+     *
+     *    Content of *Space* has been updated.
+     *
+     *    Summary of Changes:
+     *    • New pages: Page1, Page2
+     *    • Modified pages: Page3
+     *    • Deleted pages: Page4, Page5
+     *    • Moved pages: Page6
+     *    • New files: File1, File2
+     *    • Modified files: File3
+     *    • Deleted files: File4
+     *
+     *    And another X changes are not listed here.
+     */
+
+    const createdPages = [];
+    const editedPages = [];
+    const deletedPages = [];
+    const movedPages = [];
+    const createdFiles = [];
+    const editedFiles = [];
+    const deletedFiles = [];
+
+    semanticChanges.changes.forEach((change) => {
+        switch (change.type) {
+            case RevisionSemanticChangeType.PageCreated:
+                createdPages.push(change.page.title);
+                break;
+            case RevisionSemanticChangeType.PageEdited:
+                editedPages.push(change.page.title);
+                break;
+            case RevisionSemanticChangeType.PageDeleted:
+                deletedPages.push(change.page.title);
+                break;
+            case RevisionSemanticChangeType.PageMoved:
+                movedPages.push(change.page.title);
+                break;
+            case RevisionSemanticChangeType.FileCreated:
+                createdFiles.push(change.file.name);
+                break;
+            case RevisionSemanticChangeType.FileEdited:
+                editedFiles.push(change.file.name);
+                break;
+            case RevisionSemanticChangeType.FileDeleted:
+                deletedFiles.push(change.file.name);
+                break;
+            default:
+                break;
+        }
+    });
+
+    let notificationText = `Content of *${space.title || 'Space'}* has been updated.`;
+
+    if (
+        createdPages.length > 0 ||
+        editedPages.length > 0 ||
+        deletedPages.length > 0 ||
+        movedPages.length > 0 ||
+        createdFiles.length > 0 ||
+        editedFiles.length > 0 ||
+        deletedFiles.length > 0
+    ) {
+        notificationText += '\n\nSummary of Changes:';
+
+        if (createdPages.length > 0) {
+            notificationText += `\n• New pages: ${createdPages.join(', ')}`;
+        }
+        if (editedPages.length > 0) {
+            notificationText += `\n• Modified pages: ${editedPages.join(', ')}`;
+        }
+        if (deletedPages.length > 0) {
+            notificationText += `\n• Deleted pages: ${deletedPages.join(', ')}`;
+        }
+        if (movedPages.length > 0) {
+            notificationText += `\n• Moved pages: ${movedPages.join(', ')}`;
+        }
+        if (createdFiles.length > 0) {
+            notificationText += `\n• New files: ${createdFiles.join(', ')}`;
+        }
+        if (editedFiles.length > 0) {
+            notificationText += `\n• Modified files: ${editedFiles.join(', ')}`;
+        }
+        if (deletedFiles.length > 0) {
+            notificationText += `\n• Deleted files: ${deletedFiles.join(', ')}`;
+        }
+
+        if (semanticChanges.more > 0) {
+            notificationText += `\n\nAnd another ${semanticChanges.more} changes not listed here.`;
+        }
+    }
 
     await slackAPI(context, {
         method: 'POST',
@@ -38,9 +146,7 @@ const handleSpaceContentUpdated: EventCallback<
                     type: 'section',
                     text: {
                         type: 'mrkdwn',
-                        text: `Content of *<${space.urls.app}|${
-                            space.title || 'Space'
-                        }>* has been updated`,
+                        text: notificationText,
                     },
                 },
             ],

--- a/integrations/slack/src/index.ts
+++ b/integrations/slack/src/index.ts
@@ -57,7 +57,7 @@ const handleSpaceContentUpdated: EventCallback<
      *    • Modified files: File3
      *    • Deleted files: File4
      *
-     *    And another X changes are not listed here.
+     *    And another X changes not listed here.
      */
 
     const createdPages = [];
@@ -96,7 +96,9 @@ const handleSpaceContentUpdated: EventCallback<
         }
     });
 
-    let notificationText = `Content of *${space.title || 'Space'}* has been updated.`;
+    let notificationText = `Content of *<${space.urls.app}|${
+        space.title || 'Space'
+    }>* has been updated.`;
 
     if (
         createdPages.length > 0 ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -479,7 +479,7 @@
         },
         "integrations/slack": {
             "name": "@gitbook/integration-slack",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "dependencies": {
                 "@gitbook/runtime": "*",
                 "itty-router": "^2.6.1",
@@ -11869,7 +11869,7 @@
         },
         "packages/api": {
             "name": "@gitbook/api",
-            "version": "0.11.0",
+            "version": "0.15.0",
             "dependencies": {
                 "swagger-typescript-api": "^9.3.1"
             },
@@ -12114,7 +12114,7 @@
         },
         "packages/runtime": {
             "name": "@gitbook/runtime",
-            "version": "0.9.0",
+            "version": "0.10.0",
             "dependencies": {
                 "@gitbook/api": "*"
             },


### PR DESCRIPTION
Uses the new space revision semantic changes API to build a detailed summary of what changed, when receiving a `space_content_updated` event callback, and use that for the Slack notification text.