### PR TITLE
Fix bug where CLI fails when installing dependencies on Windows machines

### DIFF
--- a/.changeset/sweet-seahorses-complain.md
+++ b/.changeset/sweet-seahorses-complain.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/cli': minor
+---
+
+Updates the CLI to check for Windows machines in order to install dependencies correctly

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -171,7 +171,7 @@ export async function extendPackageJson(dirPath: string, projectName: string): P
  */
 export function installDependencies(dirPath: string): Promise<void> {
     return new Promise((resolve, reject) => {
-        const install = spawn('npm', ['install'], {
+        const install = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install'], {
             stdio: 'inherit',
             cwd: dirPath,
         });


### PR DESCRIPTION
This PR should fix the issue where initializing a new GitBook project fails due to the engine installing dependencies not installing them correctly on Windows machines.