### PR TITLE
Update swagger-typescript-api@13.0.3

### DIFF
--- a/.changeset/silent-fishes-pretend.md
+++ b/.changeset/silent-fishes-pretend.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/api': minor
+---
+
+Update swagger-typescript-api and fix passing signal to requests

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,7 @@
                 "jose": "^4.14.4"
             },
             "devDependencies": {
-                "@gitbook/cli": "^0.13.0",
+                "@gitbook/cli": "^0.14.0",
                 "@gitbook/eslint-config": "*",
                 "@gitbook/tsconfig": "*",
                 "@octokit/webhooks-types": "^7.2.0",
@@ -156,7 +156,7 @@
             },
             "devDependencies": {
                 "@gitbook/api": "*",
-                "@gitbook/cli": "^0.13.0",
+                "@gitbook/cli": "^0.14.0",
                 "@gitbook/eslint-config": "*",
                 "@gitbook/runtime": "*",
                 "@gitbook/tsconfig": "*"
@@ -217,7 +217,7 @@
                 "dotenv": "^16.1.1"
             },
             "devDependencies": {
-                "@gitbook/cli": "^0.13.0",
+                "@gitbook/cli": "^0.14.0",
                 "@gitbook/eslint-config": "*",
                 "@gitbook/runtime": "*",
                 "@gitbook/tsconfig": "*"
@@ -479,7 +479,7 @@
         },
         "integrations/slack": {
             "name": "@gitbook/integration-slack",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "dependencies": {
                 "@gitbook/runtime": "*",
                 "itty-router": "^2.6.1",
@@ -4566,6 +4566,17 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@sindresorhus/is": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
+            "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
         "node_modules/@stoplight/json": {
             "version": "3.18.1",
             "license": "Apache-2.0",
@@ -4775,6 +4786,7 @@
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/prompts": {
@@ -4796,6 +4808,7 @@
         },
         "node_modules/@types/swagger-schema-official": {
             "version": "2.0.21",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/urijs": {
@@ -5359,6 +5372,7 @@
         },
         "node_modules/axios": {
             "version": "0.21.4",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.14.0"
@@ -5740,6 +5754,14 @@
             "dev": true,
             "license": "0BSD"
         },
+        "node_modules/char-regex": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/chardet": {
             "version": "0.7.0",
             "license": "MIT"
@@ -5918,6 +5940,7 @@
         },
         "node_modules/commander": {
             "version": "6.2.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
@@ -6005,6 +6028,7 @@
         },
         "node_modules/cosmiconfig": {
             "version": "7.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
@@ -6079,6 +6103,14 @@
         "node_modules/csv-stringify": {
             "version": "5.6.5",
             "license": "MIT"
+        },
+        "node_modules/data-uri-to-buffer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+            "engines": {
+                "node": ">= 12"
+            }
         },
         "node_modules/dataloader": {
             "version": "2.2.2",
@@ -6203,6 +6235,11 @@
                 "node": ">=8"
             }
         },
+        "node_modules/didyoumean": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+            "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+        },
         "node_modules/diff": {
             "version": "4.0.2",
             "dev": true,
@@ -6315,6 +6352,11 @@
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "license": "MIT"
+        },
+        "node_modules/emojilib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+            "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="
         },
         "node_modules/enquirer": {
             "version": "2.3.6",
@@ -6842,6 +6884,7 @@
         },
         "node_modules/eta": {
             "version": "1.12.3",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -7043,6 +7086,28 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/fetch-blob": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20 || >= 14.13"
+            }
+        },
         "node_modules/figures": {
             "version": "3.2.0",
             "dev": true,
@@ -7120,6 +7185,7 @@
         },
         "node_modules/follow-redirects": {
             "version": "1.15.1",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -7178,6 +7244,17 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "dependencies": {
+                "fetch-blob": "^3.1.2"
+            },
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/formspree": {
@@ -8614,6 +8691,7 @@
         },
         "node_modules/make-dir": {
             "version": "3.1.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "semver": "^6.0.0"
@@ -8627,6 +8705,7 @@
         },
         "node_modules/make-dir/node_modules/semver": {
             "version": "6.3.0",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -8904,8 +8983,15 @@
             "license": "ISC"
         },
         "node_modules/nanoid": {
-            "version": "3.3.4",
-            "license": "MIT",
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -8933,7 +9019,6 @@
         },
         "node_modules/node-domexception": {
             "version": "1.0.0",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -8951,6 +9036,7 @@
         },
         "node_modules/node-emoji": {
             "version": "1.11.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.21"
@@ -10383,6 +10469,17 @@
             "version": "1.0.5",
             "license": "MIT"
         },
+        "node_modules/skin-tone": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+            "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+            "dependencies": {
+                "unicode-emoji-modifier-base": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/slash": {
             "version": "3.0.0",
             "license": "MIT",
@@ -10894,6 +10991,7 @@
         },
         "node_modules/swagger-typescript-api": {
             "version": "9.3.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/swagger-schema-official": "2.0.21",
@@ -11388,6 +11486,14 @@
                 "node": ">=12.18"
             }
         },
+        "node_modules/unicode-emoji-modifier-base": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+            "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/universalify": {
             "version": "0.1.2",
             "license": "MIT",
@@ -11556,7 +11662,6 @@
         },
         "node_modules/web-streams-polyfill": {
             "version": "3.2.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -11869,9 +11974,9 @@
         },
         "packages/api": {
             "name": "@gitbook/api",
-            "version": "0.15.0",
+            "version": "0.19.0",
             "dependencies": {
-                "swagger-typescript-api": "^9.3.1"
+                "swagger-typescript-api": "^13.0.3"
             },
             "devDependencies": {
                 "@gitbook/eslint-config": "*",
@@ -11882,9 +11987,135 @@
                 "typescript": "^4.6.3"
             }
         },
+        "packages/api/node_modules/@types/swagger-schema-official": {
+            "version": "2.0.22",
+            "resolved": "https://registry.npmjs.org/@types/swagger-schema-official/-/swagger-schema-official-2.0.22.tgz",
+            "integrity": "sha512-7yQiX6MWSFSvc/1wW5smJMZTZ4fHOd+hqLr3qr/HONDxHEa2bnYAsOcGBOEqFIjd4yetwMOdEDdeW+udRAQnHA=="
+        },
+        "packages/api/node_modules/cosmiconfig": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+            "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+            "dependencies": {
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^4.1.0",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/d-fischer"
+            }
+        },
+        "packages/api/node_modules/eta": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/eta/-/eta-2.2.0.tgz",
+            "integrity": "sha512-UVQ72Rqjy/ZKQalzV5dCCJP80GrmPrMxh6NlNf+erV6ObL0ZFkhCstWRawS85z3smdr3d2wXPsZEY7rDPfGd2g==",
+            "engines": {
+                "node": ">=6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/eta-dev/eta?sponsor=1"
+            }
+        },
+        "packages/api/node_modules/make-dir": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/api/node_modules/node-emoji": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.0.tgz",
+            "integrity": "sha512-tcsBm9C6FmPN5Wo7OjFi9lgMyJjvkAeirmjR/ax8Ttfqy4N8PoFic26uqFTIgayHPNI5FH4ltUvfh9kHzwcK9A==",
+            "dependencies": {
+                "@sindresorhus/is": "^3.1.2",
+                "char-regex": "^1.0.2",
+                "emojilib": "^2.4.0",
+                "skin-tone": "^2.0.0"
+            }
+        },
+        "packages/api/node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
+            }
+        },
+        "packages/api/node_modules/prettier": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+            "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "packages/api/node_modules/swagger-typescript-api": {
+            "version": "13.0.3",
+            "resolved": "https://registry.npmjs.org/swagger-typescript-api/-/swagger-typescript-api-13.0.3.tgz",
+            "integrity": "sha512-774ndLpGm2FNpUZpDugfoOO2pIcvSW9nlcqwLVSH9ju4YKCi1Gd83jPly7upcljOvZ8KO/edIUx+9eYViDYglg==",
+            "dependencies": {
+                "@types/swagger-schema-official": "2.0.22",
+                "cosmiconfig": "8.2.0",
+                "didyoumean": "^1.2.2",
+                "eta": "^2.2.0",
+                "js-yaml": "4.1.0",
+                "lodash": "4.17.21",
+                "make-dir": "4.0.0",
+                "nanoid": "3.3.6",
+                "node-emoji": "2.1.0",
+                "node-fetch": "^3.3.1",
+                "prettier": "3.0.0",
+                "swagger-schema-official": "2.0.0-bab6bed",
+                "swagger2openapi": "7.0.8",
+                "typescript": "5.1.6"
+            },
+            "bin": {
+                "sta": "index.js",
+                "swagger-typescript-api": "index.js"
+            }
+        },
+        "packages/api/node_modules/swagger-typescript-api/node_modules/typescript": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
         "packages/cli": {
             "name": "@gitbook/cli",
-            "version": "0.13.1",
+            "version": "0.14.0",
             "hasInstallScript": true,
             "dependencies": {
                 "@gitbook/api": "*",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,7 +12,7 @@
         "dist/**"
     ],
     "dependencies": {
-        "swagger-typescript-api": "^9.3.1"
+        "swagger-typescript-api": "^13.0.3"
     },
     "devDependencies": {
         "swagger-cli": "^4.0.4",


### PR DESCRIPTION
To solve an issue with `signal` option being ignored when passed as an option to requests.

I can't see any breaking changes that might impact our integrations.