### PR TITLE
Fix an issue where GA, Heap, and Hotjar integrations could interfere with the global scope of the page.

### DIFF
--- a/.changeset/pretty-parrots-cheer.md
+++ b/.changeset/pretty-parrots-cheer.md
@@ -1,0 +1,7 @@
+---
+'@gitbook/integration-googleanalytics': minor
+'@gitbook/integration-hotjar': minor
+'@gitbook/integration-heap': minor
+---
+
+Fix an issue where GA, Heap, and Hotjar integrations could pollute the global scope of the page.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
     "eslint.format.enable": true,
     // Fix errors on save using ESLint
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     // Format using Prettier to format on save
     "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/integrations/googleanalytics/src/script.raw.js
+++ b/integrations/googleanalytics/src/script.raw.js
@@ -1,35 +1,34 @@
-const trackingID = '<TO_REPLACE>';
+(function (win, doc, script, layer) {
+    const id = '<TO_REPLACE>';
+    const GRANTED_COOKIE = '__gitbook_cookie_granted';
 
-const GANTED_COOKIE = '__gitbook_cookie_granted';
-
-function getCookie(cname) {
-    const name = `${cname}=`;
-    const decodedCookie = decodeURIComponent(document.cookie);
-    const ca = decodedCookie.split(';');
-    for (let i = 0; i < ca.length; i++) {
-        let c = ca[i];
-        while (c.charAt(0) === ' ') {
-            c = c.substring(1);
-        }
-        if (c.indexOf(name) === 0) {
-            return c.substring(name.length, c.length);
-        }
+    function triggerView(win) {
+        win.gtag('event', 'page_view', {
+            page_path: win.location.pathname,
+            page_location: win.location.href,
+            page_title: win.document.title,
+            send_to: 'tracking_views',
+        });
     }
-    return '';
-}
 
-function triggerView(win) {
-    win.gtag('event', 'page_view', {
-        page_path: win.location.pathname,
-        page_location: win.location.href,
-        page_title: win.document.title,
-        send_to: 'tracking_views',
-    });
-}
+    function getCookie(cname) {
+        const name = `${cname}=`;
+        const decodedCookie = decodeURIComponent(document.cookie);
+        const ca = decodedCookie.split(';');
+        for (let i = 0; i < ca.length; i++) {
+            let c = ca[i];
+            while (c.charAt(0) === ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) === 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return '';
+    }
 
-(function (win, doc, script, layer, id) {
     let disableCookies = false;
-    const cookie = getCookie(GANTED_COOKIE);
+    const cookie = getCookie(GRANTED_COOKIE);
     if (cookie === 'yes') {
         disableCookies = false;
     } else if (cookie === 'no') {
@@ -69,4 +68,4 @@ function triggerView(win) {
         });
     };
     f.parentNode.insertBefore(j, f);
-})(window, document, 'script', 'dataLayer', trackingID);
+})(window, document, 'script', 'dataLayer');

--- a/integrations/heap/src/script.raw.js
+++ b/integrations/heap/src/script.raw.js
@@ -1,26 +1,36 @@
-const trackingID = '<TO_REPLACE>';
-
-(function (win, doc, trackingID) {
-    win.heap=win.heap||[]
-    heap.load=function(e,t) {
-    win.heap.appid = e, win.heap.config=t=t||{};
-    var r=doc.createElement("script");
-    r.type="text/javascript", 
-    r.async=!0,
-    r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";
-    var a=doc.getElementsByTagName("script")[0];
-    a.parentNode.insertBefore(r,a);
-    for(var n=function(e){
-      return function () {
-        heap.push([e].concat(Array.prototype.slice.call(arguments,0)))
-      }
-    }, p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],
-      o=0; o < p.length; o++)
-    heap[p[o]] = n(p[o])
-  };
-  heap.load(trackingID);
-})(window, document, trackingID);
-
-
-
-  
+(function (win, doc) {
+    const trackingID = '<TO_REPLACE>';
+    win.heap = win.heap || [];
+    heap.load = function (e, t) {
+        (win.heap.appid = e), (win.heap.config = t = t || {});
+        var r = doc.createElement('script');
+        (r.type = 'text/javascript'),
+            (r.async = !0),
+            (r.src = 'https://cdn.heapanalytics.com/js/heap-' + e + '.js');
+        var a = doc.getElementsByTagName('script')[0];
+        a.parentNode.insertBefore(r, a);
+        for (
+            var n = function (e) {
+                    return function () {
+                        heap.push([e].concat(Array.prototype.slice.call(arguments, 0)));
+                    };
+                },
+                p = [
+                    'addEventProperties',
+                    'addUserProperties',
+                    'clearEventProperties',
+                    'identify',
+                    'resetIdentity',
+                    'removeEventProperty',
+                    'setEventProperties',
+                    'track',
+                    'unsetEventProperty',
+                ],
+                o = 0;
+            o < p.length;
+            o++
+        )
+            heap[p[o]] = n(p[o]);
+    };
+    heap.load(trackingID);
+})(window, document);

--- a/integrations/hotjar/src/script.raw.js
+++ b/integrations/hotjar/src/script.raw.js
@@ -1,6 +1,5 @@
-const trackingID = '<TO_REPLACE>';
-
 (function (h, o, t, j, a, r) {
+    const trackingID = '<TO_REPLACE>';
     h.hj =
         h.hj ||
         function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11974,7 +11974,7 @@
         },
         "packages/api": {
             "name": "@gitbook/api",
-            "version": "0.19.0",
+            "version": "0.20.1",
             "dependencies": {
                 "swagger-typescript-api": "^13.0.3"
             },


### PR DESCRIPTION
All injected scripts should keep any variables to local scopes.