### PR TITLE
Send event timestamp when triggering Git sync imports and exports

### DIFF
--- a/integrations/github/src/index.ts
+++ b/integrations/github/src/index.ts
@@ -354,7 +354,7 @@ const handleSpaceContentUpdated: EventCallback<
     }
 
     await triggerExport(context, spaceInstallation, {
-        eventCreatedAt: new Date(revision.createdAt),
+        eventTimestamp: new Date(revision.createdAt),
     });
 };
 

--- a/integrations/github/src/index.ts
+++ b/integrations/github/src/index.ts
@@ -353,7 +353,9 @@ const handleSpaceContentUpdated: EventCallback<
         return;
     }
 
-    await triggerExport(context, spaceInstallation);
+    await triggerExport(context, spaceInstallation, {
+        eventCreatedAt: new Date(revision.createdAt),
+    });
 };
 
 /*

--- a/integrations/github/src/sync.ts
+++ b/integrations/github/src/sync.ts
@@ -43,10 +43,18 @@ export async function triggerImport(
 
         /** Whether the git info should be updated on the space */
         updateGitInfo?: boolean;
+
+        /**
+         * The date/time of the event that triggers the import.
+         *
+         * This is to help ensures that Git sync import and export operations are executed
+         * in the same order on GitBook and on the remote repository.
+         */
+        eventCreatedAt?: Date;
     } = {}
 ) {
     const { api } = context;
-    const { force = false, updateGitInfo = false, standalone } = options;
+    const { force = false, updateGitInfo = false, standalone, eventCreatedAt } = options;
 
     const config = getSpaceConfigOrThrow(spaceInstallation);
     assertIsDefined(config.branch, { label: 'config.branch' });
@@ -68,6 +76,7 @@ export async function triggerImport(
         repoProjectDirectory: config.projectDirectory,
         repoCacheID: config.key,
         force,
+        timestamp: eventCreatedAt && !force ? eventCreatedAt.toISOString() : undefined,
         standalone: !!standalone,
         ...(updateGitInfo ? { gitInfo: { provider: 'github', url: repoURL } } : {}),
     });
@@ -85,10 +94,18 @@ export async function triggerExport(
 
         /** Whether the git info should be updated on the space */
         updateGitInfo?: boolean;
+
+        /**
+         * The date/time of the event that triggers the export.
+         *
+         * This is to help ensures that Git sync import and export operations are executed
+         * in the same order on GitBook and on the remote repository.
+         */
+        eventCreatedAt?: Date;
     } = {}
 ) {
     const { api } = context;
-    const { force = false, updateGitInfo = false } = options;
+    const { force = false, updateGitInfo = false, eventCreatedAt } = options;
 
     const config = getSpaceConfigOrThrow(spaceInstallation);
     assertIsDefined(config.branch, { label: 'config.branch' });
@@ -112,6 +129,7 @@ export async function triggerExport(
         repoProjectDirectory: config.projectDirectory,
         repoCacheID: config.key,
         force,
+        timestamp: eventCreatedAt && !force ? eventCreatedAt.toISOString() : undefined,
         commitMessage: getCommitMessageForRevision(config, revision),
         ...(updateGitInfo ? { gitInfo: { provider: 'github', url: repoURL } } : {}),
     });

--- a/integrations/github/src/sync.ts
+++ b/integrations/github/src/sync.ts
@@ -45,16 +45,16 @@ export async function triggerImport(
         updateGitInfo?: boolean;
 
         /**
-         * The date/time of the event that triggers the import.
+         * The timestamp of the event that triggers the import.
          *
          * This is to help ensures that Git sync import and export operations are executed
          * in the same order on GitBook and on the remote repository.
          */
-        eventCreatedAt?: Date;
+        eventTimestamp?: Date;
     } = {}
 ) {
     const { api } = context;
-    const { force = false, updateGitInfo = false, standalone, eventCreatedAt } = options;
+    const { force = false, updateGitInfo = false, standalone, eventTimestamp } = options;
 
     const config = getSpaceConfigOrThrow(spaceInstallation);
     assertIsDefined(config.branch, { label: 'config.branch' });
@@ -76,7 +76,7 @@ export async function triggerImport(
         repoProjectDirectory: config.projectDirectory,
         repoCacheID: config.key,
         force,
-        timestamp: eventCreatedAt && !force ? eventCreatedAt.toISOString() : undefined,
+        timestamp: eventTimestamp && !force ? eventTimestamp.toISOString() : undefined,
         standalone: !!standalone,
         ...(updateGitInfo ? { gitInfo: { provider: 'github', url: repoURL } } : {}),
     });
@@ -96,16 +96,16 @@ export async function triggerExport(
         updateGitInfo?: boolean;
 
         /**
-         * The date/time of the event that triggers the export.
+         * The timestamp of the event that triggers the export.
          *
          * This is to help ensures that Git sync import and export operations are executed
          * in the same order on GitBook and on the remote repository.
          */
-        eventCreatedAt?: Date;
+        eventTimestamp?: Date;
     } = {}
 ) {
     const { api } = context;
-    const { force = false, updateGitInfo = false, eventCreatedAt } = options;
+    const { force = false, updateGitInfo = false, eventTimestamp } = options;
 
     const config = getSpaceConfigOrThrow(spaceInstallation);
     assertIsDefined(config.branch, { label: 'config.branch' });
@@ -129,7 +129,7 @@ export async function triggerExport(
         repoProjectDirectory: config.projectDirectory,
         repoCacheID: config.key,
         force,
-        timestamp: eventCreatedAt && !force ? eventCreatedAt.toISOString() : undefined,
+        timestamp: eventTimestamp && !force ? eventTimestamp.toISOString() : undefined,
         commitMessage: getCommitMessageForRevision(config, revision),
         ...(updateGitInfo ? { gitInfo: { provider: 'github', url: repoURL } } : {}),
     });

--- a/integrations/github/src/tasks.ts
+++ b/integrations/github/src/tasks.ts
@@ -50,7 +50,7 @@ export async function handleImportDispatchForSpaces(
     context: GithubRuntimeContext,
     payload: IntegrationTaskImportSpaces['payload']
 ): Promise<number | undefined> {
-    const { configQuery, page, standaloneRef } = payload;
+    const { configQuery, page, standaloneRef, eventTimestamp } = payload;
 
     logger.debug(`handling import dispatch for spaces with payload: ${JSON.stringify(payload)}`);
 
@@ -92,6 +92,7 @@ export async function handleImportDispatchForSpaces(
                               ref: standaloneRef,
                           }
                         : undefined,
+                    eventTimestamp,
                 });
             } catch (error) {
                 logger.error(

--- a/integrations/github/src/types.ts
+++ b/integrations/github/src/types.ts
@@ -93,6 +93,13 @@ export type IntegrationTaskImportSpaces = BaseIntegrationTask<
         configQuery: string;
         page?: string;
         standaloneRef?: string;
+        /**
+         * The timestamp of the event that triggers the export.
+         *
+         * This is to help ensures that Git sync import and export operations are executed
+         * in the same order on GitBook and on the remote repository.
+         */
+        eventTimestamp?: Date;
     }
 >;
 

--- a/integrations/github/src/webhooks.ts
+++ b/integrations/github/src/webhooks.ts
@@ -85,7 +85,7 @@ export async function handlePushEvent(
                     });
 
                     await triggerImport(context, spaceInstallation, {
-                        eventCreatedAt: payload.head_commit?.timestamp
+                        eventTimestamp: payload.head_commit?.timestamp
                             ? new Date(payload.head_commit?.timestamp)
                             : undefined,
                     });
@@ -151,7 +151,7 @@ export async function handlePullRequestEvents(
                         standalone: {
                             ref: headRef,
                         },
-                        eventCreatedAt:
+                        eventTimestamp:
                             payload.action === 'opened'
                                 ? new Date(payload.pull_request.created_at)
                                 : new Date(payload.pull_request.updated_at),

--- a/integrations/github/src/webhooks.ts
+++ b/integrations/github/src/webhooks.ts
@@ -151,10 +151,6 @@ export async function handlePullRequestEvents(
                         standalone: {
                             ref: headRef,
                         },
-                        eventTimestamp:
-                            payload.action === 'opened'
-                                ? new Date(payload.pull_request.created_at)
-                                : new Date(payload.pull_request.updated_at),
                     });
                 } catch (error) {
                     logger.error(

--- a/integrations/github/src/webhooks.ts
+++ b/integrations/github/src/webhooks.ts
@@ -151,6 +151,10 @@ export async function handlePullRequestEvents(
                         standalone: {
                             ref: headRef,
                         },
+                        eventCreatedAt:
+                            payload.action === 'opened'
+                                ? new Date(payload.pull_request.created_at)
+                                : new Date(payload.pull_request.updated_at),
                     });
                 } catch (error) {
                     logger.error(

--- a/integrations/github/src/webhooks.ts
+++ b/integrations/github/src/webhooks.ts
@@ -66,7 +66,7 @@ export async function handlePushEvent(
         const total = await handleImportDispatchForSpaces(context, {
             configQuery: queryKey,
             eventTimestamp: payload.head_commit?.timestamp
-                ? new Date(payload.head_commit?.timestamp)
+                ? new Date(payload.head_commit.timestamp)
                 : undefined,
         });
 

--- a/integrations/github/src/webhooks.ts
+++ b/integrations/github/src/webhooks.ts
@@ -65,6 +65,9 @@ export async function handlePushEvent(
 
         const total = await handleImportDispatchForSpaces(context, {
             configQuery: queryKey,
+            eventTimestamp: payload.head_commit?.timestamp
+                ? new Date(payload.head_commit?.timestamp)
+                : undefined,
         });
 
         logger.debug(`${total} space configurations are affected`);

--- a/integrations/github/src/webhooks.ts
+++ b/integrations/github/src/webhooks.ts
@@ -84,7 +84,11 @@ export async function handlePushEvent(
                         authToken: installationAPIToken.token,
                     });
 
-                    await triggerImport(context, spaceInstallation);
+                    await triggerImport(context, spaceInstallation, {
+                        eventCreatedAt: payload.head_commit?.timestamp
+                            ? new Date(payload.head_commit?.timestamp)
+                            : undefined,
+                    });
                 } catch (error) {
                     logger.error(
                         `error while triggering import for space ${spaceInstallation.space}`,

--- a/integrations/gitlab/src/index.ts
+++ b/integrations/gitlab/src/index.ts
@@ -264,7 +264,9 @@ const handleSpaceContentUpdated: EventCallback<
         return;
     }
 
-    await triggerExport(context, spaceInstallation);
+    await triggerExport(context, spaceInstallation, {
+        eventCreatedAt: new Date(revision.createdAt),
+    });
 };
 
 /*

--- a/integrations/gitlab/src/index.ts
+++ b/integrations/gitlab/src/index.ts
@@ -265,7 +265,7 @@ const handleSpaceContentUpdated: EventCallback<
     }
 
     await triggerExport(context, spaceInstallation, {
-        eventCreatedAt: new Date(revision.createdAt),
+        eventTimestamp: new Date(revision.createdAt),
     });
 };
 

--- a/integrations/gitlab/src/sync.ts
+++ b/integrations/gitlab/src/sync.ts
@@ -43,10 +43,18 @@ export async function triggerImport(
 
         /** Whether the git info should be updated on the space */
         updateGitInfo?: boolean;
+
+        /**
+         * The date/time of the event that triggers the import.
+         *
+         * This is to help ensures that Git sync import and export operations are executed
+         * in the same order on GitBook and on the remote repository.
+         */
+        eventCreatedAt?: Date;
     } = {}
 ) {
     const { api } = context;
-    const { force = false, updateGitInfo = false, standalone } = options;
+    const { force = false, updateGitInfo = false, standalone, eventCreatedAt } = options;
 
     const config = getSpaceConfigOrThrow(spaceInstallation);
     assertIsDefined(config.branch, { label: 'config.branch' });
@@ -68,6 +76,7 @@ export async function triggerImport(
         repoProjectDirectory: config.projectDirectory,
         repoCacheID: config.key,
         force,
+        timestamp: eventCreatedAt && !force ? eventCreatedAt.toISOString() : undefined,
         standalone: !!standalone,
         ...(updateGitInfo ? { gitInfo: { provider: 'gitlab', url: repoURL } } : {}),
     });
@@ -85,10 +94,18 @@ export async function triggerExport(
 
         /** Whether the git info should be updated on the space */
         updateGitInfo?: boolean;
+
+        /**
+         * The date/time of the event that triggers the export.
+         *
+         * This is to help ensures that Git sync import and export operations are executed
+         * in the same order on GitBook and on the remote repository.
+         */
+        eventCreatedAt?: Date;
     } = {}
 ) {
     const { api } = context;
-    const { force = false, updateGitInfo = false } = options;
+    const { force = false, updateGitInfo = false, eventCreatedAt } = options;
 
     const config = getSpaceConfigOrThrow(spaceInstallation);
     assertIsDefined(config.branch, { label: 'config.branch' });
@@ -112,6 +129,7 @@ export async function triggerExport(
         repoProjectDirectory: config.projectDirectory,
         repoCacheID: config.key,
         force,
+        timestamp: eventCreatedAt && !force ? eventCreatedAt.toISOString() : undefined,
         commitMessage: getCommitMessageForRevision(config, revision),
         ...(updateGitInfo ? { gitInfo: { provider: 'gitlab', url: repoURL } } : {}),
     });

--- a/integrations/gitlab/src/sync.ts
+++ b/integrations/gitlab/src/sync.ts
@@ -45,16 +45,16 @@ export async function triggerImport(
         updateGitInfo?: boolean;
 
         /**
-         * The date/time of the event that triggers the import.
+         * The timestamp of the event that triggers the import.
          *
          * This is to help ensures that Git sync import and export operations are executed
          * in the same order on GitBook and on the remote repository.
          */
-        eventCreatedAt?: Date;
+        eventTimestamp?: Date;
     } = {}
 ) {
     const { api } = context;
-    const { force = false, updateGitInfo = false, standalone, eventCreatedAt } = options;
+    const { force = false, updateGitInfo = false, standalone, eventTimestamp } = options;
 
     const config = getSpaceConfigOrThrow(spaceInstallation);
     assertIsDefined(config.branch, { label: 'config.branch' });
@@ -76,7 +76,7 @@ export async function triggerImport(
         repoProjectDirectory: config.projectDirectory,
         repoCacheID: config.key,
         force,
-        timestamp: eventCreatedAt && !force ? eventCreatedAt.toISOString() : undefined,
+        timestamp: eventTimestamp && !force ? eventTimestamp.toISOString() : undefined,
         standalone: !!standalone,
         ...(updateGitInfo ? { gitInfo: { provider: 'gitlab', url: repoURL } } : {}),
     });
@@ -96,16 +96,16 @@ export async function triggerExport(
         updateGitInfo?: boolean;
 
         /**
-         * The date/time of the event that triggers the export.
+         * The timestamp of the event that triggers the export.
          *
          * This is to help ensures that Git sync import and export operations are executed
          * in the same order on GitBook and on the remote repository.
          */
-        eventCreatedAt?: Date;
+        eventTimestamp?: Date;
     } = {}
 ) {
     const { api } = context;
-    const { force = false, updateGitInfo = false, eventCreatedAt } = options;
+    const { force = false, updateGitInfo = false, eventTimestamp } = options;
 
     const config = getSpaceConfigOrThrow(spaceInstallation);
     assertIsDefined(config.branch, { label: 'config.branch' });
@@ -129,7 +129,7 @@ export async function triggerExport(
         repoProjectDirectory: config.projectDirectory,
         repoCacheID: config.key,
         force,
-        timestamp: eventCreatedAt && !force ? eventCreatedAt.toISOString() : undefined,
+        timestamp: eventTimestamp && !force ? eventTimestamp.toISOString() : undefined,
         commitMessage: getCommitMessageForRevision(config, revision),
         ...(updateGitInfo ? { gitInfo: { provider: 'gitlab', url: repoURL } } : {}),
     });

--- a/integrations/gitlab/src/tasks.ts
+++ b/integrations/gitlab/src/tasks.ts
@@ -50,7 +50,7 @@ export async function handleImportDispatchForSpaces(
     context: GitLabRuntimeContext,
     payload: IntegrationTaskImportSpaces['payload']
 ): Promise<number | undefined> {
-    const { configQuery, page, standaloneRef } = payload;
+    const { configQuery, page, standaloneRef, eventTimestamp } = payload;
 
     logger.debug(`handling import dispatch for spaces with payload: ${JSON.stringify(payload)}`);
 
@@ -92,6 +92,7 @@ export async function handleImportDispatchForSpaces(
                               ref: standaloneRef,
                           }
                         : undefined,
+                    eventTimestamp,
                 });
             } catch (error) {
                 logger.error(

--- a/integrations/gitlab/src/types.ts
+++ b/integrations/gitlab/src/types.ts
@@ -87,6 +87,13 @@ export type IntegrationTaskImportSpaces = BaseIntegrationTask<
         configQuery: string;
         page?: string;
         standaloneRef?: string;
+        /**
+         * The timestamp of the event that triggers the export.
+         *
+         * This is to help ensures that Git sync import and export operations are executed
+         * in the same order on GitBook and on the remote repository.
+         */
+        eventTimestamp?: Date;
     }
 >;
 

--- a/integrations/gitlab/src/webhooks.ts
+++ b/integrations/gitlab/src/webhooks.ts
@@ -111,7 +111,7 @@ export async function handlePushEvent(context: GitLabRuntimeContext, payload: Gi
 
     const total = await handleImportDispatchForSpaces(context, {
         configQuery: queryKey,
-        eventTimestamp: headCommit ? new Date(headCommit.timestamp) : undefined,
+        eventTimestamp: headCommit?.timestamp ? new Date(headCommit.timestamp) : undefined,
     });
 
     logger.debug(`${total} space configurations are affected`);

--- a/integrations/gitlab/src/webhooks.ts
+++ b/integrations/gitlab/src/webhooks.ts
@@ -103,8 +103,15 @@ export async function handlePushEvent(context: GitLabRuntimeContext, payload: Gi
 
     const queryKey = computeConfigQueryKey(gitlabProjectId, gitlabRef);
 
+    // Gitlab push events do not include a head_commit property so we need to get it from
+    // the commits attribute which should contains the newest 20 commits:
+    // https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#push-events
+    const headCommitSha = payload.after;
+    const headCommit = payload.commits.find((commit) => commit.id === headCommitSha);
+
     const total = await handleImportDispatchForSpaces(context, {
         configQuery: queryKey,
+        eventTimestamp: headCommit ? new Date(headCommit.timestamp) : undefined,
     });
 
     logger.debug(`${total} space configurations are affected`);

--- a/integrations/gitlab/src/webhooks.ts
+++ b/integrations/gitlab/src/webhooks.ts
@@ -194,10 +194,6 @@ export async function handleMergeRequestEvent(
                         standalone: {
                             ref: sourceRef,
                         },
-                        eventTimestamp:
-                            payload.object_attributes.action === 'open'
-                                ? new Date(payload.object_attributes.created_at)
-                                : new Date(payload.object_attributes.updated_at),
                     });
                 } catch (error) {
                     logger.error(

--- a/integrations/gitlab/src/webhooks.ts
+++ b/integrations/gitlab/src/webhooks.ts
@@ -133,7 +133,7 @@ export async function handlePushEvent(context: GitLabRuntimeContext, payload: Gi
                 });
 
                 await triggerImport(context, spaceInstallation, {
-                    eventCreatedAt: headCommit ? new Date(headCommit.timestamp) : undefined,
+                    eventTimestamp: headCommit ? new Date(headCommit.timestamp) : undefined,
                 });
             } catch (error) {
                 logger.error(
@@ -194,7 +194,7 @@ export async function handleMergeRequestEvent(
                         standalone: {
                             ref: sourceRef,
                         },
-                        eventCreatedAt:
+                        eventTimestamp:
                             payload.object_attributes.action === 'open'
                                 ? new Date(payload.object_attributes.created_at)
                                 : new Date(payload.object_attributes.updated_at),

--- a/integrations/gitlab/src/webhooks.ts
+++ b/integrations/gitlab/src/webhooks.ts
@@ -171,6 +171,10 @@ export async function handleMergeRequestEvent(
                         standalone: {
                             ref: sourceRef,
                         },
+                        eventCreatedAt:
+                            payload.object_attributes.action === 'open'
+                                ? new Date(payload.object_attributes.created_at)
+                                : new Date(payload.object_attributes.updated_at),
                     });
                 } catch (error) {
                     logger.error(


### PR DESCRIPTION
Following https://github.com/GitbookIO/gitbook-x/pull/9118, updating the Git integration to send the event timestamp when triggering imports and exports via the API.