### PR TITLE
Update integrations publish workflow for production

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://unpkg.com/@changesets/config@2.0.0/schema.json",
+    "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
     "changelog": "@changesets/cli/changelog",
     "commit": false,
     "fixed": [],
@@ -7,5 +7,9 @@
     "access": "public",
     "baseBranch": "main",
     "updateInternalDependencies": "patch",
-    "ignore": []
+    "ignore": [],
+    "privatePackages": {
+        "tag": true,
+        "version": true
+    }
 }

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,70 @@
+name: Release integration to production
+
+on:
+    release:
+        types: [published]
+
+jobs:
+    deploy-integration-to-production:
+        name: Deploy integration to production
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v3
+
+            - name: Setup Node.js 20.x
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 20.x
+
+            - name: Install Dependencies
+              # We need to build and then re-install so that the "bin" can be correctly linked
+              run: |
+                  npm ci
+                  npm run build
+                  npm ci
+
+            # TODO: Remove this once we incorporate this in the publish API of the integration
+            - name: Publish all integrations assets to production
+              run: npm run publish-assets
+              env:
+                  CLOUDFLARE_PAGES_PROJECT: ${{ secrets.INTEGRATIONS_ASSETS_PROD_PROJECT }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
+
+            - name: Deploy integration
+              run: npm run publish-integrations -- --filter=${{ github.event.release.tag_name }}
+              env:
+                  GITBOOK_TOKEN: ${{ secrets.GITBOOK_PROD_API_TOKEN }}
+                  GITBOOK_ENDPOINT: https://api.gitbook.com
+                  GITBOOK_ORGANIZATION: gitbook
+                  UNFURL_GITHUB_CLIENT_ID: ${{ secrets.UNFURL_GITHUB_CLIENT_ID }}
+                  UNFURL_GITHUB_CLIENT_SECRET: ${{ secrets.UNFURL_GITHUB_CLIENT_SECRET }}
+                  GITLAB_CLIENT_ID: ${{ secrets.GITLAB_CLIENT_ID }}
+                  GITLAB_CLIENT_SECRET: ${{ secrets.GITLAB_CLIENT_SECRET }}
+                  DISCORD_CLIENT_ID: $ {{ secrets.DISCORD_CLIENT_ID }}
+                  DISCORD_CLIENT_SECRET: $ {{ secrets.DISCORD_CLIENT_SECRET }}
+                  DISCORD_BOT_TOKEN: $ {{ secrets.DISCORD_BOT_TOKEN }}
+                  SLACK_CLIENT_ID: ${{ secrets.SLACK_PROD_CLIENT_ID }}
+                  SLACK_CLIENT_SECRET: ${{ secrets.SLACK_PROD_CLIENT_SECRET }}
+                  SLACK_SIGNING_SECRET: ${{ secrets.SLACK_PROD_SIGNING_SECRET }}
+                  FIGMA_CLIENT_ID: ${{ secrets.FIGMA_PROD_CLIENT_ID }}
+                  FIGMA_CLIENT_SECRET: ${{ secrets.FIGMA_PROD_CLIENT_SECRET }}
+                  MAILCHIMP_CLIENT_ID: ${{ secrets.MAILCHIMP_PROD_CLIENT_ID }}
+                  MAILCHIMP_CLIENT_SECRET: ${{ secrets.MAILCHIMP_PROD_CLIENT_SECRET }}
+                  JIRA_CLIENT_ID: ${{ secrets.JIRA_PROD_CLIENT_ID }}
+                  JIRA_CLIENT_SECRET: ${{ secrets.JIRA_PROD_CLIENT_SECRET }}
+                  LINEAR_CLIENT_ID: ${{ secrets.LINEAR_PROD_CLIENT_ID }}
+                  LINEAR_CLIENT_SECRET: ${{ secrets.LINEAR_PROD_CLIENT_SECRET }}
+                  GITHUB_APP_INSTALL_URL: ${{ secrets.GITBOOK_GITHUB_APP_INSTALL_URL }}
+                  GITHUB_APP_ID: ${{ secrets.GITBOOK_GITHUB_APP_ID }}
+                  GITHUB_CLIENT_ID: ${{ secrets.GITBOOK_GITHUB_CLIENT_ID }}
+                  GITHUB_CLIENT_SECRET: ${{ secrets.GITBOOK_GITHUB_CLIENT_SECRET }}
+                  GITHUB_WEBHOOK_SECRET: ${{ secrets.GITBOOK_GITHUB_WEBHOOK_SECRET }}
+                  GITHUB_PRIVATE_KEY: ${{ secrets.GITBOOK_GITHUB_PRIVATE_KEY }}
+                  GITHUB_ENTITIES_APP_INSTALL_URL: ${{ secrets.ENTITIES_GITHUB_APP_INSTALL_URL }}
+                  GITHUB_ENTITIES_APP_ID: ${{ secrets.ENTITIES_GITHUB_APP_ID }}
+                  GITHUB_ENTITIES_CLIENT_ID: ${{ secrets.ENTITIES_GITHUB_CLIENT_ID }}
+                  GITHUB_ENTITIES_CLIENT_SECRET: ${{ secrets.ENTITIES_GITHUB_CLIENT_SECRET }}
+                  GITHUB_ENTITIES_WEBHOOK_SECRET: ${{ secrets.ENTITIES_GITHUB_WEBHOOK_SECRET }}
+                  GITHUB_ENTITIES_PRIVATE_KEY: ${{ secrets.ENTITIES_GITHUB_PRIVATE_KEY }}

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
     deploy-integration-to-production:
+        if: github.event.release.draft == false && github.event.release.prerelease == false && startsWith(github.event.release.tag_name, '@gitbook/integration-')
         name: Deploy integration to production
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,8 +35,8 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    publish-integrations:
-        name: Publish Integrations
+    publish-integrations-staging:
+        name: Publish Integrations to Staging
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Repo
@@ -96,45 +96,3 @@ jobs:
                   GITHUB_ENTITIES_CLIENT_SECRET: ${{ secrets.ENTITIES_GITHUB_STAGING_CLIENT_SECRET }}
                   GITHUB_ENTITIES_WEBHOOK_SECRET: ${{ secrets.ENTITIES_GITHUB_STAGING_WEBHOOK_SECRET }}
                   GITHUB_ENTITIES_PRIVATE_KEY: ${{ secrets.ENTITIES_GITHUB_STAGING_PRIVATE_KEY }}
-            - name: Publish all integrations assets to production
-              run: npm run publish-assets
-              env:
-                  CLOUDFLARE_PAGES_PROJECT: ${{ secrets.INTEGRATIONS_ASSETS_PROD_PROJECT }}
-                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
-            - name: Publish all integrations to production
-              run: npm run publish-integrations
-              env:
-                  GITBOOK_TOKEN: ${{ secrets.GITBOOK_PROD_API_TOKEN }}
-                  GITBOOK_ENDPOINT: https://api.gitbook.com
-                  GITBOOK_ORGANIZATION: gitbook
-                  UNFURL_GITHUB_CLIENT_ID: ${{ secrets.UNFURL_GITHUB_CLIENT_ID }}
-                  UNFURL_GITHUB_CLIENT_SECRET: ${{ secrets.UNFURL_GITHUB_CLIENT_SECRET }}
-                  GITLAB_CLIENT_ID: ${{ secrets.GITLAB_CLIENT_ID }}
-                  GITLAB_CLIENT_SECRET: ${{ secrets.GITLAB_CLIENT_SECRET }}
-                  DISCORD_CLIENT_ID: $ {{ secrets.DISCORD_CLIENT_ID }}
-                  DISCORD_CLIENT_SECRET: $ {{ secrets.DISCORD_CLIENT_SECRET }}
-                  DISCORD_BOT_TOKEN: $ {{ secrets.DISCORD_BOT_TOKEN }}
-                  SLACK_CLIENT_ID: ${{ secrets.SLACK_PROD_CLIENT_ID }}
-                  SLACK_CLIENT_SECRET: ${{ secrets.SLACK_PROD_CLIENT_SECRET }}
-                  SLACK_SIGNING_SECRET: ${{ secrets.SLACK_PROD_SIGNING_SECRET }}
-                  FIGMA_CLIENT_ID: ${{ secrets.FIGMA_PROD_CLIENT_ID }}
-                  FIGMA_CLIENT_SECRET: ${{ secrets.FIGMA_PROD_CLIENT_SECRET }}
-                  MAILCHIMP_CLIENT_ID: ${{ secrets.MAILCHIMP_PROD_CLIENT_ID }}
-                  MAILCHIMP_CLIENT_SECRET: ${{ secrets.MAILCHIMP_PROD_CLIENT_SECRET }}
-                  JIRA_CLIENT_ID: ${{ secrets.JIRA_PROD_CLIENT_ID }}
-                  JIRA_CLIENT_SECRET: ${{ secrets.JIRA_PROD_CLIENT_SECRET }}
-                  LINEAR_CLIENT_ID: ${{ secrets.LINEAR_PROD_CLIENT_ID }}
-                  LINEAR_CLIENT_SECRET: ${{ secrets.LINEAR_PROD_CLIENT_SECRET }}
-                  GITHUB_APP_INSTALL_URL: ${{ secrets.GITBOOK_GITHUB_APP_INSTALL_URL }}
-                  GITHUB_APP_ID: ${{ secrets.GITBOOK_GITHUB_APP_ID }}
-                  GITHUB_CLIENT_ID: ${{ secrets.GITBOOK_GITHUB_CLIENT_ID }}
-                  GITHUB_CLIENT_SECRET: ${{ secrets.GITBOOK_GITHUB_CLIENT_SECRET }}
-                  GITHUB_WEBHOOK_SECRET: ${{ secrets.GITBOOK_GITHUB_WEBHOOK_SECRET }}
-                  GITHUB_PRIVATE_KEY: ${{ secrets.GITBOOK_GITHUB_PRIVATE_KEY }}
-                  GITHUB_ENTITIES_APP_INSTALL_URL: ${{ secrets.ENTITIES_GITHUB_APP_INSTALL_URL }}
-                  GITHUB_ENTITIES_APP_ID: ${{ secrets.ENTITIES_GITHUB_APP_ID }}
-                  GITHUB_ENTITIES_CLIENT_ID: ${{ secrets.ENTITIES_GITHUB_CLIENT_ID }}
-                  GITHUB_ENTITIES_CLIENT_SECRET: ${{ secrets.ENTITIES_GITHUB_CLIENT_SECRET }}
-                  GITHUB_ENTITIES_WEBHOOK_SECRET: ${{ secrets.ENTITIES_GITHUB_WEBHOOK_SECRET }}
-                  GITHUB_ENTITIES_PRIVATE_KEY: ${{ secrets.ENTITIES_GITHUB_PRIVATE_KEY }}

--- a/integrations/formspree/package.json
+++ b/integrations/formspree/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "formspree",
+    "name": "@gitbook/integration-formspree",
     "private": true,
     "scripts": {
         "lint": "eslint ./**/*.ts*",

--- a/integrations/jira/package.json
+++ b/integrations/jira/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "jira",
+    "name": "@gitbook/integration-jira",
     "private": true,
     "scripts": {
         "lint": "eslint ./**/*.ts*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
             }
         },
         "integrations/formspree": {
+            "name": "@gitbook/integration-formspree",
             "devDependencies": {
                 "@gitbook/cli": "*",
                 "@gitbook/runtime": "*"
@@ -302,6 +303,7 @@
             }
         },
         "integrations/jira": {
+            "name": "@gitbook/integration-jira",
             "dependencies": {
                 "itty-router": "^2.6.1"
             },
@@ -2565,6 +2567,10 @@
             "resolved": "integrations/figma",
             "link": true
         },
+        "node_modules/@gitbook/integration-formspree": {
+            "resolved": "integrations/formspree",
+            "link": true
+        },
         "node_modules/@gitbook/integration-github": {
             "resolved": "integrations/github",
             "link": true
@@ -2603,6 +2609,10 @@
         },
         "node_modules/@gitbook/integration-intercom": {
             "resolved": "integrations/intercom",
+            "link": true
+        },
+        "node_modules/@gitbook/integration-jira": {
+            "resolved": "integrations/jira",
             "link": true
         },
         "node_modules/@gitbook/integration-linear": {
@@ -7600,10 +7610,6 @@
                 "node": ">=12.20.0"
             }
         },
-        "node_modules/formspree": {
-            "resolved": "integrations/formspree",
-            "link": true
-        },
         "node_modules/fs-extra": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -8671,10 +8677,6 @@
         "node_modules/itty-router": {
             "version": "4.0.17",
             "license": "MIT"
-        },
-        "node_modules/jira": {
-            "resolved": "integrations/jira",
-            "link": true
         },
         "node_modules/jiti": {
             "version": "1.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,11 @@
                 "integrations/*",
                 "packages/*"
             ],
-            "dependencies": {
-                "@changesets/cli": "^2.22.0"
-            },
             "devDependencies": {
+                "@actions/core": "^1.10.1",
+                "@actions/exec": "^1.1.1",
+                "@actions/github": "^6.0.0",
+                "@changesets/cli": "^2.27.0",
                 "assert": "^2.0.0",
                 "esbuild-register": "^3.3.3",
                 "test": "^3.2.1",
@@ -116,7 +117,7 @@
                 "jose": "^4.14.4"
             },
             "devDependencies": {
-                "@gitbook/cli": "^0.14.0",
+                "@gitbook/cli": "^0.15.0",
                 "@gitbook/eslint-config": "*",
                 "@gitbook/tsconfig": "*",
                 "@octokit/webhooks-types": "^7.2.0",
@@ -156,7 +157,7 @@
             },
             "devDependencies": {
                 "@gitbook/api": "*",
-                "@gitbook/cli": "^0.14.0",
+                "@gitbook/cli": "^0.15.0",
                 "@gitbook/eslint-config": "*",
                 "@gitbook/runtime": "*",
                 "@gitbook/tsconfig": "*"
@@ -217,7 +218,7 @@
                 "dotenv": "^16.1.1"
             },
             "devDependencies": {
-                "@gitbook/cli": "^0.14.0",
+                "@gitbook/cli": "^0.15.0",
                 "@gitbook/eslint-config": "*",
                 "@gitbook/runtime": "*",
                 "@gitbook/tsconfig": "*"
@@ -247,7 +248,7 @@
         },
         "integrations/googleanalytics": {
             "name": "@gitbook/integration-googleanalytics",
-            "version": "0.0.1",
+            "version": "0.1.0",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*"
@@ -258,7 +259,7 @@
         },
         "integrations/heap": {
             "name": "@gitbook/integration-heap",
-            "version": "0.0.1",
+            "version": "0.1.0",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*"
@@ -269,7 +270,7 @@
         },
         "integrations/hotjar": {
             "name": "@gitbook/integration-hotjar",
-            "version": "0.0.1",
+            "version": "0.1.0",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*"
@@ -507,6 +508,65 @@
             "devDependencies": {
                 "@gitbook/cli": "*"
             }
+        },
+        "node_modules/@actions/core": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
+            "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+            "dev": true,
+            "dependencies": {
+                "@actions/http-client": "^2.0.1",
+                "uuid": "^8.3.2"
+            }
+        },
+        "node_modules/@actions/exec": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+            "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+            "dev": true,
+            "dependencies": {
+                "@actions/io": "^1.0.1"
+            }
+        },
+        "node_modules/@actions/github": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.0.tgz",
+            "integrity": "sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==",
+            "dev": true,
+            "dependencies": {
+                "@actions/http-client": "^2.2.0",
+                "@octokit/core": "^5.0.1",
+                "@octokit/plugin-paginate-rest": "^9.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
+            }
+        },
+        "node_modules/@actions/http-client": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.0.tgz",
+            "integrity": "sha512-q+epW0trjVUUHboliPb4UF9g2msf+w61b32tAkFEwL/IwP0DQWgbCMM0Hbe3e3WXSKz5VcUXbzJQgy8Hkra/Lg==",
+            "dev": true,
+            "dependencies": {
+                "tunnel": "^0.0.6",
+                "undici": "^5.25.4"
+            }
+        },
+        "node_modules/@actions/http-client/node_modules/undici": {
+            "version": "5.28.2",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+            "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
+            "dev": true,
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
+        },
+        "node_modules/@actions/io": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+            "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+            "dev": true
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.2.1",
@@ -1774,6 +1834,7 @@
         },
         "node_modules/@babel/runtime": {
             "version": "7.22.5",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "regenerator-runtime": "^0.13.11"
@@ -1837,14 +1898,16 @@
             }
         },
         "node_modules/@changesets/apply-release-plan": {
-            "version": "6.1.4",
-            "license": "MIT",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.0.tgz",
+            "integrity": "sha512-vfi69JR416qC9hWmFGSxj7N6wA5J222XNBmezSVATPWDVPIF7gkd4d8CpbEbXmRWbVrkoli3oerGS6dcL/BGsQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.1",
-                "@changesets/config": "^2.3.1",
-                "@changesets/get-version-range-type": "^0.3.2",
-                "@changesets/git": "^2.0.0",
-                "@changesets/types": "^5.2.1",
+                "@changesets/config": "^3.0.0",
+                "@changesets/get-version-range-type": "^0.4.0",
+                "@changesets/git": "^3.0.0",
+                "@changesets/types": "^6.0.0",
                 "@manypkg/get-packages": "^1.1.3",
                 "detect-indent": "^6.0.0",
                 "fs-extra": "^7.0.1",
@@ -1857,58 +1920,65 @@
         },
         "node_modules/@changesets/apply-release-plan/node_modules/resolve-from": {
             "version": "5.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@changesets/assemble-release-plan": {
-            "version": "5.2.4",
-            "license": "MIT",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.0.tgz",
+            "integrity": "sha512-4QG7NuisAjisbW4hkLCmGW2lRYdPrKzro+fCtZaILX+3zdUELSvYjpL4GTv0E4aM9Mef3PuIQp89VmHJ4y2bfw==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.1",
-                "@changesets/errors": "^0.1.4",
-                "@changesets/get-dependents-graph": "^1.3.6",
-                "@changesets/types": "^5.2.1",
+                "@changesets/errors": "^0.2.0",
+                "@changesets/get-dependents-graph": "^2.0.0",
+                "@changesets/types": "^6.0.0",
                 "@manypkg/get-packages": "^1.1.3",
                 "semver": "^7.5.3"
             }
         },
         "node_modules/@changesets/changelog-git": {
-            "version": "0.1.14",
-            "license": "MIT",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.0.tgz",
+            "integrity": "sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==",
+            "dev": true,
             "dependencies": {
-                "@changesets/types": "^5.2.1"
+                "@changesets/types": "^6.0.0"
             }
         },
         "node_modules/@changesets/cli": {
-            "version": "2.26.2",
-            "license": "MIT",
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.27.1.tgz",
+            "integrity": "sha512-iJ91xlvRnnrJnELTp4eJJEOPjgpF3NOh4qeQehM6Ugiz9gJPRZ2t+TsXun6E3AMN4hScZKjqVXl0TX+C7AB3ZQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.1",
-                "@changesets/apply-release-plan": "^6.1.4",
-                "@changesets/assemble-release-plan": "^5.2.4",
-                "@changesets/changelog-git": "^0.1.14",
-                "@changesets/config": "^2.3.1",
-                "@changesets/errors": "^0.1.4",
-                "@changesets/get-dependents-graph": "^1.3.6",
-                "@changesets/get-release-plan": "^3.0.17",
-                "@changesets/git": "^2.0.0",
-                "@changesets/logger": "^0.0.5",
-                "@changesets/pre": "^1.0.14",
-                "@changesets/read": "^0.5.9",
-                "@changesets/types": "^5.2.1",
-                "@changesets/write": "^0.2.3",
+                "@changesets/apply-release-plan": "^7.0.0",
+                "@changesets/assemble-release-plan": "^6.0.0",
+                "@changesets/changelog-git": "^0.2.0",
+                "@changesets/config": "^3.0.0",
+                "@changesets/errors": "^0.2.0",
+                "@changesets/get-dependents-graph": "^2.0.0",
+                "@changesets/get-release-plan": "^4.0.0",
+                "@changesets/git": "^3.0.0",
+                "@changesets/logger": "^0.1.0",
+                "@changesets/pre": "^2.0.0",
+                "@changesets/read": "^0.6.0",
+                "@changesets/types": "^6.0.0",
+                "@changesets/write": "^0.3.0",
                 "@manypkg/get-packages": "^1.1.3",
-                "@types/is-ci": "^3.0.0",
                 "@types/semver": "^7.5.0",
                 "ansi-colors": "^4.1.3",
                 "chalk": "^2.1.0",
+                "ci-info": "^3.7.0",
                 "enquirer": "^2.3.0",
                 "external-editor": "^3.1.0",
                 "fs-extra": "^7.0.1",
                 "human-id": "^1.0.2",
-                "is-ci": "^3.0.1",
                 "meow": "^6.0.0",
                 "outdent": "^0.5.0",
                 "p-limit": "^2.2.0",
@@ -1925,6 +1995,7 @@
         },
         "node_modules/@changesets/cli/node_modules/ansi-styles": {
             "version": "3.2.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^1.9.0"
@@ -1935,6 +2006,7 @@
         },
         "node_modules/@changesets/cli/node_modules/chalk": {
             "version": "2.4.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^3.2.1",
@@ -1947,6 +2019,7 @@
         },
         "node_modules/@changesets/cli/node_modules/color-convert": {
             "version": "1.9.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "1.1.3"
@@ -1954,10 +2027,12 @@
         },
         "node_modules/@changesets/cli/node_modules/color-name": {
             "version": "1.1.3",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@changesets/cli/node_modules/escape-string-regexp": {
             "version": "1.0.5",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
@@ -1965,6 +2040,7 @@
         },
         "node_modules/@changesets/cli/node_modules/has-flag": {
             "version": "3.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -1972,6 +2048,7 @@
         },
         "node_modules/@changesets/cli/node_modules/p-limit": {
             "version": "2.3.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-try": "^2.0.0"
@@ -1985,6 +2062,7 @@
         },
         "node_modules/@changesets/cli/node_modules/p-try": {
             "version": "2.2.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -1992,6 +2070,7 @@
         },
         "node_modules/@changesets/cli/node_modules/resolve-from": {
             "version": "5.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -1999,6 +2078,7 @@
         },
         "node_modules/@changesets/cli/node_modules/supports-color": {
             "version": "5.5.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^3.0.0"
@@ -2008,30 +2088,36 @@
             }
         },
         "node_modules/@changesets/config": {
-            "version": "2.3.1",
-            "license": "MIT",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.0.0.tgz",
+            "integrity": "sha512-o/rwLNnAo/+j9Yvw9mkBQOZySDYyOr/q+wptRLcAVGlU6djOeP9v1nlalbL9MFsobuBVQbZCTp+dIzdq+CLQUA==",
+            "dev": true,
             "dependencies": {
-                "@changesets/errors": "^0.1.4",
-                "@changesets/get-dependents-graph": "^1.3.6",
-                "@changesets/logger": "^0.0.5",
-                "@changesets/types": "^5.2.1",
+                "@changesets/errors": "^0.2.0",
+                "@changesets/get-dependents-graph": "^2.0.0",
+                "@changesets/logger": "^0.1.0",
+                "@changesets/types": "^6.0.0",
                 "@manypkg/get-packages": "^1.1.3",
                 "fs-extra": "^7.0.1",
                 "micromatch": "^4.0.2"
             }
         },
         "node_modules/@changesets/errors": {
-            "version": "0.1.4",
-            "license": "MIT",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
+            "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
+            "dev": true,
             "dependencies": {
                 "extendable-error": "^0.1.5"
             }
         },
         "node_modules/@changesets/get-dependents-graph": {
-            "version": "1.3.6",
-            "license": "MIT",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.0.0.tgz",
+            "integrity": "sha512-cafUXponivK4vBgZ3yLu944mTvam06XEn2IZGjjKc0antpenkYANXiiE6GExV/yKdsCnE8dXVZ25yGqLYZmScA==",
+            "dev": true,
             "dependencies": {
-                "@changesets/types": "^5.2.1",
+                "@changesets/types": "^6.0.0",
                 "@manypkg/get-packages": "^1.1.3",
                 "chalk": "^2.1.0",
                 "fs-extra": "^7.0.1",
@@ -2040,7 +2126,9 @@
         },
         "node_modules/@changesets/get-dependents-graph/node_modules/ansi-styles": {
             "version": "3.2.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -2050,7 +2138,9 @@
         },
         "node_modules/@changesets/get-dependents-graph/node_modules/chalk": {
             "version": "2.4.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -2062,32 +2152,42 @@
         },
         "node_modules/@changesets/get-dependents-graph/node_modules/color-convert": {
             "version": "1.9.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
             "dependencies": {
                 "color-name": "1.1.3"
             }
         },
         "node_modules/@changesets/get-dependents-graph/node_modules/color-name": {
             "version": "1.1.3",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
         },
         "node_modules/@changesets/get-dependents-graph/node_modules/escape-string-regexp": {
             "version": "1.0.5",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@changesets/get-dependents-graph/node_modules/has-flag": {
             "version": "3.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/@changesets/get-dependents-graph/node_modules/supports-color": {
             "version": "5.5.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
@@ -2096,29 +2196,35 @@
             }
         },
         "node_modules/@changesets/get-release-plan": {
-            "version": "3.0.17",
-            "license": "MIT",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.0.tgz",
+            "integrity": "sha512-9L9xCUeD/Tb6L/oKmpm8nyzsOzhdNBBbt/ZNcjynbHC07WW4E1eX8NMGC5g5SbM5z/V+MOrYsJ4lRW41GCbg3w==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.1",
-                "@changesets/assemble-release-plan": "^5.2.4",
-                "@changesets/config": "^2.3.1",
-                "@changesets/pre": "^1.0.14",
-                "@changesets/read": "^0.5.9",
-                "@changesets/types": "^5.2.1",
+                "@changesets/assemble-release-plan": "^6.0.0",
+                "@changesets/config": "^3.0.0",
+                "@changesets/pre": "^2.0.0",
+                "@changesets/read": "^0.6.0",
+                "@changesets/types": "^6.0.0",
                 "@manypkg/get-packages": "^1.1.3"
             }
         },
         "node_modules/@changesets/get-version-range-type": {
-            "version": "0.3.2",
-            "license": "MIT"
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
+            "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==",
+            "dev": true
         },
         "node_modules/@changesets/git": {
-            "version": "2.0.0",
-            "license": "MIT",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.0.tgz",
+            "integrity": "sha512-vvhnZDHe2eiBNRFHEgMiGd2CT+164dfYyrJDhwwxTVD/OW0FUD6G7+4DIx1dNwkwjHyzisxGAU96q0sVNBns0w==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.1",
-                "@changesets/errors": "^0.1.4",
-                "@changesets/types": "^5.2.1",
+                "@changesets/errors": "^0.2.0",
+                "@changesets/types": "^6.0.0",
                 "@manypkg/get-packages": "^1.1.3",
                 "is-subdir": "^1.1.1",
                 "micromatch": "^4.0.2",
@@ -2126,15 +2232,19 @@
             }
         },
         "node_modules/@changesets/logger": {
-            "version": "0.0.5",
-            "license": "MIT",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.0.tgz",
+            "integrity": "sha512-pBrJm4CQm9VqFVwWnSqKEfsS2ESnwqwH+xR7jETxIErZcfd1u2zBSqrHbRHR7xjhSgep9x2PSKFKY//FAshA3g==",
+            "dev": true,
             "dependencies": {
                 "chalk": "^2.1.0"
             }
         },
         "node_modules/@changesets/logger/node_modules/ansi-styles": {
             "version": "3.2.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -2144,7 +2254,9 @@
         },
         "node_modules/@changesets/logger/node_modules/chalk": {
             "version": "2.4.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -2156,32 +2268,42 @@
         },
         "node_modules/@changesets/logger/node_modules/color-convert": {
             "version": "1.9.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
             "dependencies": {
                 "color-name": "1.1.3"
             }
         },
         "node_modules/@changesets/logger/node_modules/color-name": {
             "version": "1.1.3",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
         },
         "node_modules/@changesets/logger/node_modules/escape-string-regexp": {
             "version": "1.0.5",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@changesets/logger/node_modules/has-flag": {
             "version": "3.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/@changesets/logger/node_modules/supports-color": {
             "version": "5.5.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
@@ -2190,23 +2312,29 @@
             }
         },
         "node_modules/@changesets/parse": {
-            "version": "0.3.16",
-            "license": "MIT",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.0.tgz",
+            "integrity": "sha512-TS/9KG2CdGXS27S+QxbZXgr8uPsP4yNJYb4BC2/NeFUj80Rni3TeD2qwWmabymxmrLo7JEsytXH1FbpKTbvivw==",
+            "dev": true,
             "dependencies": {
-                "@changesets/types": "^5.2.1",
+                "@changesets/types": "^6.0.0",
                 "js-yaml": "^3.13.1"
             }
         },
         "node_modules/@changesets/parse/node_modules/argparse": {
             "version": "1.0.10",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
         },
         "node_modules/@changesets/parse/node_modules/js-yaml": {
             "version": "3.14.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -2216,25 +2344,29 @@
             }
         },
         "node_modules/@changesets/pre": {
-            "version": "1.0.14",
-            "license": "MIT",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.0.tgz",
+            "integrity": "sha512-HLTNYX/A4jZxc+Sq8D1AMBsv+1qD6rmmJtjsCJa/9MSRybdxh0mjbTvE6JYZQ/ZiQ0mMlDOlGPXTm9KLTU3jyw==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.1",
-                "@changesets/errors": "^0.1.4",
-                "@changesets/types": "^5.2.1",
+                "@changesets/errors": "^0.2.0",
+                "@changesets/types": "^6.0.0",
                 "@manypkg/get-packages": "^1.1.3",
                 "fs-extra": "^7.0.1"
             }
         },
         "node_modules/@changesets/read": {
-            "version": "0.5.9",
-            "license": "MIT",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.0.tgz",
+            "integrity": "sha512-ZypqX8+/im1Fm98K4YcZtmLKgjs1kDQ5zHpc2U1qdtNBmZZfo/IBiG162RoP0CUF05tvp2y4IspH11PLnPxuuw==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.1",
-                "@changesets/git": "^2.0.0",
-                "@changesets/logger": "^0.0.5",
-                "@changesets/parse": "^0.3.16",
-                "@changesets/types": "^5.2.1",
+                "@changesets/git": "^3.0.0",
+                "@changesets/logger": "^0.1.0",
+                "@changesets/parse": "^0.4.0",
+                "@changesets/types": "^6.0.0",
                 "chalk": "^2.1.0",
                 "fs-extra": "^7.0.1",
                 "p-filter": "^2.1.0"
@@ -2242,7 +2374,9 @@
         },
         "node_modules/@changesets/read/node_modules/ansi-styles": {
             "version": "3.2.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -2252,7 +2386,9 @@
         },
         "node_modules/@changesets/read/node_modules/chalk": {
             "version": "2.4.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -2264,32 +2400,42 @@
         },
         "node_modules/@changesets/read/node_modules/color-convert": {
             "version": "1.9.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
             "dependencies": {
                 "color-name": "1.1.3"
             }
         },
         "node_modules/@changesets/read/node_modules/color-name": {
             "version": "1.1.3",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
         },
         "node_modules/@changesets/read/node_modules/escape-string-regexp": {
             "version": "1.0.5",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@changesets/read/node_modules/has-flag": {
             "version": "3.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/@changesets/read/node_modules/supports-color": {
             "version": "5.5.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
@@ -2298,15 +2444,19 @@
             }
         },
         "node_modules/@changesets/types": {
-            "version": "5.2.1",
-            "license": "MIT"
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
+            "integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
+            "dev": true
         },
         "node_modules/@changesets/write": {
-            "version": "0.2.3",
-            "license": "MIT",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.3.0.tgz",
+            "integrity": "sha512-slGLb21fxZVUYbyea+94uFiD6ntQW0M2hIKNznFizDhZPDgn2c/fv1UzzlW43RVzh1BEDuIqW6hzlJ1OflNmcw==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.1",
-                "@changesets/types": "^5.2.1",
+                "@changesets/types": "^6.0.0",
                 "fs-extra": "^7.0.1",
                 "human-id": "^1.0.2",
                 "prettier": "^2.7.1"
@@ -2373,6 +2523,15 @@
         "node_modules/@exodus/schemasafe": {
             "version": "1.0.0-rc.6",
             "license": "MIT"
+        },
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+            "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/@gitbook/api": {
             "resolved": "packages/api",
@@ -4085,7 +4244,9 @@
         },
         "node_modules/@manypkg/find-root": {
             "version": "1.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.5.5",
                 "@types/node": "^12.7.1",
@@ -4095,11 +4256,15 @@
         },
         "node_modules/@manypkg/find-root/node_modules/@types/node": {
             "version": "12.20.55",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+            "dev": true
         },
         "node_modules/@manypkg/find-root/node_modules/find-up": {
             "version": "4.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
             "dependencies": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -4110,7 +4275,9 @@
         },
         "node_modules/@manypkg/find-root/node_modules/fs-extra": {
             "version": "8.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^4.0.0",
@@ -4122,7 +4289,9 @@
         },
         "node_modules/@manypkg/find-root/node_modules/locate-path": {
             "version": "5.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
             "dependencies": {
                 "p-locate": "^4.1.0"
             },
@@ -4132,7 +4301,9 @@
         },
         "node_modules/@manypkg/find-root/node_modules/p-limit": {
             "version": "2.3.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
             "dependencies": {
                 "p-try": "^2.0.0"
             },
@@ -4145,7 +4316,9 @@
         },
         "node_modules/@manypkg/find-root/node_modules/p-locate": {
             "version": "4.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
             "dependencies": {
                 "p-limit": "^2.2.0"
             },
@@ -4155,21 +4328,27 @@
         },
         "node_modules/@manypkg/find-root/node_modules/p-try": {
             "version": "2.2.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/@manypkg/find-root/node_modules/path-exists": {
             "version": "4.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@manypkg/get-packages": {
             "version": "1.1.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
+            "integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.5.5",
                 "@changesets/types": "^4.0.1",
@@ -4181,11 +4360,15 @@
         },
         "node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
             "version": "4.1.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==",
+            "dev": true
         },
         "node_modules/@manypkg/get-packages/node_modules/fs-extra": {
             "version": "8.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^4.0.0",
@@ -4493,6 +4676,134 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@octokit/auth-token": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.2.tgz",
+            "integrity": "sha512-cZUy1gUvd4vttMic7C0lwPed8IYXWYp8kHIMatyhY8t8n3Cpw2ILczkV5pGMPqef7v0bLo0pOHrEHarsau2Ydg==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.0.0",
+                "@octokit/request": "^8.0.2",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/endpoint": {
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.4.tgz",
+            "integrity": "sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/types": "^12.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/graphql": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.2.tgz",
+            "integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/request": "^8.0.1",
+                "@octokit/types": "^12.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/openapi-types": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-19.1.0.tgz",
+            "integrity": "sha512-6G+ywGClliGQwRsjvqVYpklIfa7oRPA0vyhPQG/1Feh+B+wU0vGH1JiJ5T25d3g1JZYBHzR2qefLi9x8Gt+cpw==",
+            "dev": true
+        },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "9.1.5",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.1.5.tgz",
+            "integrity": "sha512-WKTQXxK+bu49qzwv4qKbMMRXej1DU2gq017euWyKVudA6MldaSSQuxtz+vGbhxV4CjxpUxjZu6rM2wfc1FiWVg==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/types": "^12.4.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=5"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.2.0.tgz",
+            "integrity": "sha512-ePbgBMYtGoRNXDyKGvr9cyHjQ163PbwD0y1MkDJCpkO2YH4OeXX40c4wYHKikHGZcpGPbcRLuy0unPUuafco8Q==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/types": "^12.3.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=5"
+            }
+        },
+        "node_modules/@octokit/request": {
+            "version": "8.1.6",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.6.tgz",
+            "integrity": "sha512-YhPaGml3ncZC1NfXpP3WZ7iliL1ap6tLkAp6MvbK2fTTPytzVUyUesBBogcdMm86uRYO5rHaM1xIWxigWZ17MQ==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/endpoint": "^9.0.0",
+                "@octokit/request-error": "^5.0.0",
+                "@octokit/types": "^12.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/request-error": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
+            "integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/types": "^12.0.0",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@octokit/types": {
+            "version": "12.4.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.4.0.tgz",
+            "integrity": "sha512-FLWs/AvZllw/AGVs+nJ+ELCDZZJk+kY0zMen118xhL2zD0s1etIUHm1odgjP7epxYU1ln7SZxEUWYop5bhsdgQ==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/openapi-types": "^19.1.0"
+            }
+        },
         "node_modules/@octokit/webhooks-types": {
             "version": "7.2.0",
             "dev": true,
@@ -4746,13 +5057,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/is-ci": {
-            "version": "3.0.0",
-            "license": "MIT",
-            "dependencies": {
-                "ci-info": "^3.1.0"
-            }
-        },
         "node_modules/@types/js-yaml": {
             "version": "4.0.5",
             "dev": true,
@@ -4773,6 +5077,7 @@
         },
         "node_modules/@types/minimist": {
             "version": "1.2.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/node": {
@@ -4782,6 +5087,7 @@
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/parse-json": {
@@ -4799,6 +5105,7 @@
         },
         "node_modules/@types/semver": {
             "version": "7.5.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/stack-trace": {
@@ -5167,6 +5474,7 @@
         },
         "node_modules/ansi-colors": {
             "version": "4.1.3",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -5291,6 +5599,7 @@
         },
         "node_modules/arrify": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -5442,9 +5751,17 @@
             ],
             "license": "MIT"
         },
+        "node_modules/before-after-hook": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+            "dev": true
+        },
         "node_modules/better-path-resolve": {
             "version": "1.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+            "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+            "dev": true,
             "dependencies": {
                 "is-windows": "^1.0.0"
             },
@@ -5518,6 +5835,7 @@
         },
         "node_modules/breakword": {
             "version": "1.0.6",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "wcwidth": "^1.0.1"
@@ -5645,6 +5963,7 @@
         },
         "node_modules/camelcase": {
             "version": "5.3.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -5652,6 +5971,7 @@
         },
         "node_modules/camelcase-keys": {
             "version": "6.2.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "camelcase": "^5.3.1",
@@ -5764,6 +6084,7 @@
         },
         "node_modules/chardet": {
             "version": "0.7.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/check-node-version": {
@@ -5829,14 +6150,16 @@
             }
         },
         "node_modules/ci-info": {
-            "version": "3.8.0",
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/sibiraj-s"
                 }
             ],
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -6081,6 +6404,7 @@
         },
         "node_modules/csv": {
             "version": "5.5.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "csv-generate": "^3.4.3",
@@ -6094,14 +6418,17 @@
         },
         "node_modules/csv-generate": {
             "version": "3.4.3",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/csv-parse": {
             "version": "4.16.3",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/csv-stringify": {
             "version": "5.6.5",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/data-uri-to-buffer": {
@@ -6152,6 +6479,7 @@
         },
         "node_modules/decamelize": {
             "version": "1.2.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -6159,6 +6487,7 @@
         },
         "node_modules/decamelize-keys": {
             "version": "1.1.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "decamelize": "^1.1.0",
@@ -6173,6 +6502,7 @@
         },
         "node_modules/decamelize-keys/node_modules/map-obj": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -6228,8 +6558,15 @@
                 "node": ">= 0.6.0"
             }
         },
+        "node_modules/deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+            "dev": true
+        },
         "node_modules/detect-indent": {
             "version": "6.1.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -6360,6 +6697,7 @@
         },
         "node_modules/enquirer": {
             "version": "2.3.6",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-colors": "^4.1.1"
@@ -6834,6 +7172,7 @@
         },
         "node_modules/esprima": {
             "version": "4.0.1",
+            "dev": true,
             "license": "BSD-2-Clause",
             "bin": {
                 "esparse": "bin/esparse.js",
@@ -6963,10 +7302,13 @@
         },
         "node_modules/extendable-error": {
             "version": "0.1.7",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
+            "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
+            "dev": true
         },
         "node_modules/external-editor": {
             "version": "3.1.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chardet": "^0.7.0",
@@ -7162,6 +7504,7 @@
         },
         "node_modules/find-yarn-workspace-root2": {
             "version": "1.2.16",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "micromatch": "^4.0.2",
@@ -7263,7 +7606,9 @@
         },
         "node_modules/fs-extra": {
             "version": "7.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -7474,10 +7819,12 @@
         },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/grapheme-splitter": {
             "version": "1.0.4",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/graphql": {
@@ -7614,6 +7961,7 @@
         },
         "node_modules/hard-rejection": {
             "version": "2.1.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -7706,6 +8054,7 @@
         },
         "node_modules/hosted-git-info": {
             "version": "2.8.9",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/html-rewriter-wasm": {
@@ -7769,7 +8118,9 @@
         },
         "node_modules/human-id": {
             "version": "1.0.2",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/human-id/-/human-id-1.0.2.tgz",
+            "integrity": "sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==",
+            "dev": true
         },
         "node_modules/human-signals": {
             "version": "3.0.1",
@@ -7781,6 +8132,7 @@
         },
         "node_modules/iconv-lite": {
             "version": "0.4.24",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3"
@@ -7857,6 +8209,7 @@
         },
         "node_modules/indent-string": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -8007,16 +8360,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-ci": {
-            "version": "3.0.1",
-            "license": "MIT",
-            "dependencies": {
-                "ci-info": "^3.2.0"
-            },
-            "bin": {
-                "is-ci": "bin.js"
-            }
-        },
         "node_modules/is-core-module": {
             "version": "2.9.0",
             "license": "MIT",
@@ -8153,6 +8496,7 @@
         },
         "node_modules/is-plain-obj": {
             "version": "1.1.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -8219,7 +8563,9 @@
         },
         "node_modules/is-subdir": {
             "version": "1.2.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
+            "integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
+            "dev": true,
             "dependencies": {
                 "better-path-resolve": "1.0.0"
             },
@@ -8304,6 +8650,7 @@
         },
         "node_modules/is-windows": {
             "version": "1.0.2",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -8429,7 +8776,9 @@
         },
         "node_modules/jsonfile": {
             "version": "4.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "dev": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -8444,6 +8793,7 @@
         },
         "node_modules/kind-of": {
             "version": "6.0.3",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -8513,6 +8863,7 @@
         },
         "node_modules/load-yaml-file": {
             "version": "0.2.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.1.5",
@@ -8526,6 +8877,7 @@
         },
         "node_modules/load-yaml-file/node_modules/argparse": {
             "version": "1.0.10",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
@@ -8533,6 +8885,7 @@
         },
         "node_modules/load-yaml-file/node_modules/js-yaml": {
             "version": "3.14.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -8571,7 +8924,9 @@
         },
         "node_modules/lodash.startcase": {
             "version": "4.4.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+            "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+            "dev": true
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
@@ -8726,6 +9081,7 @@
         },
         "node_modules/map-obj": {
             "version": "4.3.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -8740,6 +9096,7 @@
         },
         "node_modules/meow": {
             "version": "6.1.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/minimist": "^1.2.0",
@@ -8763,6 +9120,7 @@
         },
         "node_modules/meow/node_modules/type-fest": {
             "version": "0.13.1",
+            "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=10"
@@ -8773,6 +9131,7 @@
         },
         "node_modules/meow/node_modules/yargs-parser": {
             "version": "18.1.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "camelcase": "^5.0.0",
@@ -8858,6 +9217,7 @@
         },
         "node_modules/min-indent": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -8937,6 +9297,7 @@
         },
         "node_modules/minimist-options": {
             "version": "4.1.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "arrify": "^1.0.1",
@@ -8949,6 +9310,7 @@
         },
         "node_modules/mixme": {
             "version": "0.5.9",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8.0.0"
@@ -9097,6 +9459,7 @@
         },
         "node_modules/normalize-package-data": {
             "version": "2.5.0",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^2.1.4",
@@ -9107,6 +9470,7 @@
         },
         "node_modules/normalize-package-data/node_modules/semver": {
             "version": "5.7.1",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver"
@@ -9365,6 +9729,7 @@
         },
         "node_modules/os-tmpdir": {
             "version": "1.0.2",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -9372,11 +9737,15 @@
         },
         "node_modules/outdent": {
             "version": "0.5.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
+            "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
+            "dev": true
         },
         "node_modules/p-filter": {
             "version": "2.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+            "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+            "dev": true,
             "dependencies": {
                 "p-map": "^2.0.0"
             },
@@ -9406,7 +9775,9 @@
         },
         "node_modules/p-map": {
             "version": "2.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -9577,6 +9948,7 @@
         },
         "node_modules/pify": {
             "version": "4.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -9584,6 +9956,7 @@
         },
         "node_modules/pkg-dir": {
             "version": "4.2.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "find-up": "^4.0.0"
@@ -9594,6 +9967,7 @@
         },
         "node_modules/pkg-dir/node_modules/find-up": {
             "version": "4.1.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "locate-path": "^5.0.0",
@@ -9605,6 +9979,7 @@
         },
         "node_modules/pkg-dir/node_modules/locate-path": {
             "version": "5.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-locate": "^4.1.0"
@@ -9615,6 +9990,7 @@
         },
         "node_modules/pkg-dir/node_modules/p-limit": {
             "version": "2.3.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-try": "^2.0.0"
@@ -9628,6 +10004,7 @@
         },
         "node_modules/pkg-dir/node_modules/p-locate": {
             "version": "4.1.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-limit": "^2.2.0"
@@ -9638,6 +10015,7 @@
         },
         "node_modules/pkg-dir/node_modules/p-try": {
             "version": "2.2.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -9645,6 +10023,7 @@
         },
         "node_modules/pkg-dir/node_modules/path-exists": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9713,6 +10092,7 @@
         },
         "node_modules/preferred-pm": {
             "version": "3.0.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "find-up": "^5.0.0",
@@ -9726,6 +10106,7 @@
         },
         "node_modules/preferred-pm/node_modules/find-up": {
             "version": "5.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "locate-path": "^6.0.0",
@@ -9740,6 +10121,7 @@
         },
         "node_modules/preferred-pm/node_modules/locate-path": {
             "version": "6.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-locate": "^5.0.0"
@@ -9753,6 +10135,7 @@
         },
         "node_modules/preferred-pm/node_modules/p-limit": {
             "version": "3.1.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "yocto-queue": "^0.1.0"
@@ -9766,6 +10149,7 @@
         },
         "node_modules/preferred-pm/node_modules/p-locate": {
             "version": "5.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-limit": "^3.0.2"
@@ -9779,6 +10163,7 @@
         },
         "node_modules/preferred-pm/node_modules/path-exists": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9843,7 +10228,9 @@
         },
         "node_modules/pseudomap": {
             "version": "1.0.2",
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+            "dev": true
         },
         "node_modules/punycode": {
             "version": "2.1.1",
@@ -9893,6 +10280,7 @@
         },
         "node_modules/quick-lru": {
             "version": "4.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9900,6 +10288,7 @@
         },
         "node_modules/read-pkg": {
             "version": "5.2.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/normalize-package-data": "^2.4.0",
@@ -9913,6 +10302,7 @@
         },
         "node_modules/read-pkg-up": {
             "version": "7.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "find-up": "^4.1.0",
@@ -9928,6 +10318,7 @@
         },
         "node_modules/read-pkg-up/node_modules/find-up": {
             "version": "4.1.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "locate-path": "^5.0.0",
@@ -9939,6 +10330,7 @@
         },
         "node_modules/read-pkg-up/node_modules/locate-path": {
             "version": "5.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-locate": "^4.1.0"
@@ -9949,6 +10341,7 @@
         },
         "node_modules/read-pkg-up/node_modules/p-limit": {
             "version": "2.3.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-try": "^2.0.0"
@@ -9962,6 +10355,7 @@
         },
         "node_modules/read-pkg-up/node_modules/p-locate": {
             "version": "4.1.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-limit": "^2.2.0"
@@ -9972,6 +10366,7 @@
         },
         "node_modules/read-pkg-up/node_modules/p-try": {
             "version": "2.2.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -9979,6 +10374,7 @@
         },
         "node_modules/read-pkg-up/node_modules/path-exists": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9986,6 +10382,7 @@
         },
         "node_modules/read-pkg-up/node_modules/type-fest": {
             "version": "0.8.1",
+            "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=8"
@@ -9993,6 +10390,7 @@
         },
         "node_modules/read-pkg/node_modules/type-fest": {
             "version": "0.6.0",
+            "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=8"
@@ -10000,7 +10398,9 @@
         },
         "node_modules/read-yaml-file": {
             "version": "1.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
+            "integrity": "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==",
+            "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.1.5",
                 "js-yaml": "^3.6.1",
@@ -10013,14 +10413,18 @@
         },
         "node_modules/read-yaml-file/node_modules/argparse": {
             "version": "1.0.10",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
         },
         "node_modules/read-yaml-file/node_modules/js-yaml": {
             "version": "3.14.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -10054,6 +10458,7 @@
         },
         "node_modules/redent": {
             "version": "3.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "indent-string": "^4.0.0",
@@ -10072,6 +10477,7 @@
         },
         "node_modules/regenerator-runtime": {
             "version": "0.13.11",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/regexp.prototype.flags": {
@@ -10147,6 +10553,7 @@
         },
         "node_modules/require-main-filename": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/resolve": {
@@ -10313,6 +10720,7 @@
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/scuid": {
@@ -10369,6 +10777,7 @@
         },
         "node_modules/set-blocking": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/set-cookie-parser": {
@@ -10502,6 +10911,7 @@
         },
         "node_modules/smartwrap": {
             "version": "2.0.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "array.prototype.flat": "^1.2.3",
@@ -10520,6 +10930,7 @@
         },
         "node_modules/smartwrap/node_modules/cliui": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
@@ -10529,6 +10940,7 @@
         },
         "node_modules/smartwrap/node_modules/find-up": {
             "version": "4.1.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "locate-path": "^5.0.0",
@@ -10540,6 +10952,7 @@
         },
         "node_modules/smartwrap/node_modules/locate-path": {
             "version": "5.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-locate": "^4.1.0"
@@ -10550,6 +10963,7 @@
         },
         "node_modules/smartwrap/node_modules/p-limit": {
             "version": "2.3.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-try": "^2.0.0"
@@ -10563,6 +10977,7 @@
         },
         "node_modules/smartwrap/node_modules/p-locate": {
             "version": "4.1.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-limit": "^2.2.0"
@@ -10573,6 +10988,7 @@
         },
         "node_modules/smartwrap/node_modules/p-try": {
             "version": "2.2.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -10580,6 +10996,7 @@
         },
         "node_modules/smartwrap/node_modules/path-exists": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -10587,6 +11004,7 @@
         },
         "node_modules/smartwrap/node_modules/wrap-ansi": {
             "version": "6.2.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -10599,10 +11017,12 @@
         },
         "node_modules/smartwrap/node_modules/y18n": {
             "version": "4.0.3",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/smartwrap/node_modules/yargs": {
             "version": "15.4.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cliui": "^6.0.0",
@@ -10623,6 +11043,7 @@
         },
         "node_modules/smartwrap/node_modules/yargs-parser": {
             "version": "18.1.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "camelcase": "^5.0.0",
@@ -10678,7 +11099,9 @@
         },
         "node_modules/spawndamnit": {
             "version": "2.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-2.0.0.tgz",
+            "integrity": "sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==",
+            "dev": true,
             "dependencies": {
                 "cross-spawn": "^5.1.0",
                 "signal-exit": "^3.0.2"
@@ -10686,7 +11109,9 @@
         },
         "node_modules/spawndamnit/node_modules/cross-spawn": {
             "version": "5.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+            "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
+            "dev": true,
             "dependencies": {
                 "lru-cache": "^4.0.1",
                 "shebang-command": "^1.2.0",
@@ -10695,7 +11120,9 @@
         },
         "node_modules/spawndamnit/node_modules/lru-cache": {
             "version": "4.1.5",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+            "dev": true,
             "dependencies": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
@@ -10703,7 +11130,9 @@
         },
         "node_modules/spawndamnit/node_modules/shebang-command": {
             "version": "1.2.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+            "dev": true,
             "dependencies": {
                 "shebang-regex": "^1.0.0"
             },
@@ -10713,14 +11142,18 @@
         },
         "node_modules/spawndamnit/node_modules/shebang-regex": {
             "version": "1.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/spawndamnit/node_modules/which": {
             "version": "1.3.1",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -10730,10 +11163,13 @@
         },
         "node_modules/spawndamnit/node_modules/yallist": {
             "version": "2.1.2",
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+            "dev": true
         },
         "node_modules/spdx-correct": {
             "version": "3.2.0",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "spdx-expression-parse": "^3.0.0",
@@ -10742,10 +11178,12 @@
         },
         "node_modules/spdx-exceptions": {
             "version": "2.3.0",
+            "dev": true,
             "license": "CC-BY-3.0"
         },
         "node_modules/spdx-expression-parse": {
             "version": "3.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "spdx-exceptions": "^2.1.0",
@@ -10754,6 +11192,7 @@
         },
         "node_modules/spdx-license-ids": {
             "version": "3.0.13",
+            "dev": true,
             "license": "CC0-1.0"
         },
         "node_modules/sponge-case": {
@@ -10771,6 +11210,7 @@
         },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
+            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/stack-trace": {
@@ -10812,6 +11252,7 @@
         },
         "node_modules/stream-transform": {
             "version": "2.1.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mixme": "^0.5.1"
@@ -10933,6 +11374,7 @@
         },
         "node_modules/strip-indent": {
             "version": "3.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "min-indent": "^1.0.0"
@@ -11054,6 +11496,7 @@
         },
         "node_modules/term-size": {
             "version": "2.2.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -11116,6 +11559,7 @@
         },
         "node_modules/tmp": {
             "version": "0.0.33",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "os-tmpdir": "~1.0.2"
@@ -11155,6 +11599,7 @@
         },
         "node_modules/trim-newlines": {
             "version": "3.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -11246,6 +11691,7 @@
         },
         "node_modules/tty-table": {
             "version": "4.2.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.2",
@@ -11265,6 +11711,7 @@
         },
         "node_modules/tty-table/node_modules/cliui": {
             "version": "8.0.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
@@ -11277,6 +11724,7 @@
         },
         "node_modules/tty-table/node_modules/kleur": {
             "version": "4.1.5",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -11284,6 +11732,7 @@
         },
         "node_modules/tty-table/node_modules/yargs": {
             "version": "17.7.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cliui": "^8.0.1",
@@ -11296,6 +11745,15 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
             }
         },
         "node_modules/turbo": {
@@ -11494,9 +11952,17 @@
                 "node": ">=4"
             }
         },
+        "node_modules/universal-user-agent": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+            "dev": true
+        },
         "node_modules/universalify": {
             "version": "0.1.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -11617,6 +12083,15 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
         "node_modules/v8-compile-cache": {
             "version": "2.3.0",
             "license": "MIT"
@@ -11628,6 +12103,7 @@
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "spdx-correct": "^3.0.0",
@@ -11725,10 +12201,12 @@
         },
         "node_modules/which-module": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/which-pm": {
             "version": "2.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "load-yaml-file": "^0.2.0",
@@ -11740,6 +12218,7 @@
         },
         "node_modules/which-pm/node_modules/path-exists": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -11953,6 +12432,7 @@
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -11974,7 +12454,7 @@
         },
         "packages/api": {
             "name": "@gitbook/api",
-            "version": "0.20.1",
+            "version": "0.25.0",
             "dependencies": {
                 "swagger-typescript-api": "^13.0.3"
             },
@@ -12115,7 +12595,7 @@
         },
         "packages/cli": {
             "name": "@gitbook/cli",
-            "version": "0.14.0",
+            "version": "0.15.0",
             "hasInstallScript": true,
             "dependencies": {
                 "@gitbook/api": "*",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
         "publish-assets": "./scripts/publish-assets.sh"
     },
     "devDependencies": {
+        "@actions/core": "^1.10.1",
+        "@actions/exec": "^1.1.1",
+        "@changesets/cli": "^2.27.0",
+        "@actions/github": "^6.0.0",
         "assert": "^2.0.0",
         "esbuild-register": "^3.3.3",
         "test": "^3.2.1",
@@ -32,8 +36,6 @@
         "npm": ">=7.0.0",
         "node": ">=14.0.0"
     },
-    "dependencies": {
-        "@changesets/cli": "^2.22.0"
-    },
+    "dependencies": {},
     "packageManager": "npm@8.4.1"
 }


### PR DESCRIPTION
This PR updates the CI workflow to not automatically release integrations to production when there is a push on main. In order to release an integration to prod, you must do it via changesets `npm run changeset` and select the integration to bump. 