### PR TITLE
Show updated pages as links in Slack notifications

### DIFF
--- a/.changeset/thin-hornets-return.md
+++ b/.changeset/thin-hornets-return.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-slack': minor
+---
+
+Updates to notifications showing direct page links

--- a/integrations/slack/src/index.ts
+++ b/integrations/slack/src/index.ts
@@ -1,4 +1,4 @@
-import { RevisionSemanticChangeType } from '@gitbook/api';
+import { ChangedRevisionPage, RevisionSemanticChangeType } from '@gitbook/api';
 import { createIntegration, EventCallback } from '@gitbook/runtime';
 
 import { SlackRuntimeContext } from './configuration';
@@ -72,16 +72,16 @@ const handleSpaceContentUpdated: EventCallback<
     semanticChanges.changes.forEach((change) => {
         switch (change.type) {
             case RevisionSemanticChangeType.PageCreated:
-                createdPages.push(change.page.title);
+                createdPages.push(change.page);
                 break;
             case RevisionSemanticChangeType.PageEdited:
-                editedPages.push(change.page.title);
+                editedPages.push(change.page);
                 break;
             case RevisionSemanticChangeType.PageDeleted:
-                deletedPages.push(change.page.title);
+                deletedPages.push(change.page);
                 break;
             case RevisionSemanticChangeType.PageMoved:
-                movedPages.push(change.page.title);
+                movedPages.push(change.page);
                 break;
             case RevisionSemanticChangeType.FileCreated:
                 createdFiles.push(change.file.name);
@@ -105,6 +105,10 @@ const handleSpaceContentUpdated: EventCallback<
         return list.map((item) => `• ${item}\n`).join('');
     };
 
+    const renderPageList = (list: ChangedRevisionPage[]) => {
+        return list.map((item) => `• <${space.urls.app}/${item.path}|${item.title}>\n`).join('');
+    };
+
     if (
         createdPages.length > 0 ||
         editedPages.length > 0 ||
@@ -115,7 +119,7 @@ const handleSpaceContentUpdated: EventCallback<
         deletedFiles.length > 0
     ) {
         if (createdPages.length > 0) {
-            notificationText += `\n*New pages:*\n${renderList(createdPages)}\n\n`;
+            notificationText += `\n*New pages:*\n${renderPageList(createdPages)}\n\n`;
         }
         if (editedPages.length > 0) {
             notificationText += `\n*Modified pages:*\n${renderList(editedPages)}\n\n`;

--- a/integrations/slack/src/index.ts
+++ b/integrations/slack/src/index.ts
@@ -102,7 +102,7 @@ const handleSpaceContentUpdated: EventCallback<
     }>* has been updated.`;
 
     const renderList = (list: string[]) => {
-        return list.map((item) => `• ${item}\n`);
+        return list.map((item) => `• ${item}\n`).join('');
     };
 
     if (

--- a/integrations/slack/src/index.ts
+++ b/integrations/slack/src/index.ts
@@ -106,7 +106,7 @@ const handleSpaceContentUpdated: EventCallback<
     };
 
     const renderPageList = (list: ChangedRevisionPage[]) => {
-        return list.map((item) => `• <${space.urls.app}/${item.path}|${item.title}>\n`).join('');
+        return list.map((item) => `• <${space.urls.app}${item.path}|${item.title}>\n`).join('');
     };
 
     if (
@@ -122,13 +122,13 @@ const handleSpaceContentUpdated: EventCallback<
             notificationText += `\n*New pages:*\n${renderPageList(createdPages)}\n\n`;
         }
         if (editedPages.length > 0) {
-            notificationText += `\n*Modified pages:*\n${renderList(editedPages)}\n\n`;
+            notificationText += `\n*Modified pages:*\n${renderPageList(editedPages)}\n\n`;
         }
         if (deletedPages.length > 0) {
-            notificationText += `\n*Deleted pages:*\n${renderList(deletedPages)}\n\n`;
+            notificationText += `\n*Deleted pages:*\n${renderPageList(deletedPages)}\n\n`;
         }
         if (movedPages.length > 0) {
-            notificationText += `\n*Moved pages:*\n${renderList(movedPages)}\n\n`;
+            notificationText += `\n*Moved pages:*\n${renderPageList(movedPages)}\n\n`;
         }
         if (createdFiles.length > 0) {
             notificationText += `\n*New files:*\n${renderList(createdFiles)}\n\n`;

--- a/integrations/slack/src/links.ts
+++ b/integrations/slack/src/links.ts
@@ -55,10 +55,18 @@ export async function unfurlLink(event: LinkSharedSlackEvent, context: SlackRunt
             }
 
             if ('space' in content && content.space) {
-                unfurls[link.url] = createBlocksForSpace(content.space);
+                // we don't unfurl direct pages for security reasons, so we dedupe by space here
+                if (!unfurls[content.space.urls.app]) {
+                    unfurls[content.space.urls.app] = createBlocksForSpace(content.space);
+                }
             }
             if ('collection' in content && content.collection) {
-                unfurls[link.url] = createBlocksForCollection(content.collection);
+                // we don't unfurl direct pages for security reasons, so we dedupe by collection here
+                if (!unfurls[content.collection.urls.app]) {
+                    unfurls[content.collection.urls.app] = createBlocksForCollection(
+                        content.collection
+                    );
+                }
             }
         })
     );


### PR DESCRIPTION
Shows updated pages with direct links to those pages.
Also de-dupes unfurled links so they only appear once.
