### PR TITLE
Change Okta's authorization server to default

### DIFF
--- a/.changeset/cold-waves-brush.md
+++ b/.changeset/cold-waves-brush.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-va-okta': minor
+---
+
+Use default authorization server

--- a/.changeset/cold-waves-brush.md
+++ b/.changeset/cold-waves-brush.md
@@ -1,5 +1,5 @@
 ---
-'@gitbook/integration-va-okta': minor
+'@gitbook/integration-va-okta': patch
 ---
 
 Use default authorization server

--- a/integrations/va-okta/src/index.tsx
+++ b/integrations/va-okta/src/index.tsx
@@ -191,7 +191,7 @@ const handleFetchEvent: FetchEventCallback<OktaRuntimeContext> = async (request,
                         scope: 'openid',
                         redirect_uri: `${installationURL}/visitor-auth/response`,
                     });
-                    const accessTokenURL = `https://${oktaDomain}/oauth2/default/v1/token/`;
+                    const accessTokenURL = `https://${oktaDomain}/oauth2/v1/token/`;
                     const resp: any = await fetch(accessTokenURL, {
                         method: 'POST',
                         headers: { 'content-type': 'application/x-www-form-urlencoded' },
@@ -267,7 +267,7 @@ export default createIntegration({
         const clientId = environment.spaceInstallation?.configuration.client_id;
         const location = event.location ? event.location : '';
 
-        const url = new URL(`https://${oktaDomain}/oauth2/default/v1/authorize`);
+        const url = new URL(`https://${oktaDomain}/oauth2/v1/authorize`);
         url.searchParams.append('client_id', clientId);
         url.searchParams.append('response_type', 'code');
         url.searchParams.append('redirect_uri', `${installationURL}/visitor-auth/response`);


### PR DESCRIPTION
If you include `default` in Okta's URLs, it requires an additional paid feature from the customer.

Removing the `default` forces Okta to use the default authorization server. See here for more details:

https://support.okta.com/help/s/question/0D54z00007UgqWGCAZ/error-the-requested-feature-is-not-enabled-in-this-environment?language=en_US 