### PR TITLE
Move Redirect URI instructions above the Save button for VA integrations

### DIFF
--- a/.changeset/silly-impalas-love.md
+++ b/.changeset/silly-impalas-love.md
@@ -1,0 +1,7 @@
+---
+'@gitbook/integration-va-auth0': patch
+'@gitbook/integration-va-azure': patch
+'@gitbook/integration-va-okta': patch
+---
+
+Move Redirect URI instructions above the save button

--- a/integrations/va-auth0/src/index.tsx
+++ b/integrations/va-auth0/src/index.tsx
@@ -128,7 +128,13 @@ const configBlock = createComponent<Auth0Props, Auth0State, Auth0Action, Auth0Ru
                     }
                     element={<textinput state="client_secret" placeholder="Client Secret" />}
                 />
-
+                <divider size="medium" />
+                <hint>
+                    <text style="bold">
+                        The following URL needs to be saved as an allowed callback URL in Auth0:
+                    </text>
+                </hint>
+                <codeblock content={VACallbackURL} />
                 <input
                     label=""
                     hint=""
@@ -144,11 +150,6 @@ const configBlock = createComponent<Auth0Props, Auth0State, Auth0Action, Auth0Ru
                         />
                     }
                 />
-                <divider size="medium" />
-                <text>
-                    The following URL needs to be saved as an allowed callback URL in Auth0:
-                </text>
-                <codeblock content={VACallbackURL} />
             </block>
         );
     },

--- a/integrations/va-azure/src/index.tsx
+++ b/integrations/va-azure/src/index.tsx
@@ -129,7 +129,13 @@ const configBlock = createComponent<AzureProps, AzureState, AzureAction, AzureRu
                     }
                     element={<textinput state="client_secret" placeholder="Client Secret" />}
                 />
-
+                <divider size="medium" />
+                <hint>
+                    <text style="bold">
+                        The following URL needs to be saved as an allowed Redirect URI in Azure:
+                    </text>
+                </hint>
+                <codeblock content={VACallbackURL} />
                 <input
                     label=""
                     hint=""
@@ -145,12 +151,6 @@ const configBlock = createComponent<AzureProps, AzureState, AzureAction, AzureRu
                         />
                     }
                 />
-
-                <divider size="medium" />
-                <text>
-                    The following URL needs to be saved as an allowed Redirect URI in Azure:
-                </text>
-                <codeblock content={VACallbackURL} />
             </block>
         );
     },

--- a/integrations/va-okta/src/index.tsx
+++ b/integrations/va-okta/src/index.tsx
@@ -127,7 +127,13 @@ const configBlock = createComponent<OktaProps, OktaState, OktaAction, OktaRuntim
                     }
                     element={<textinput state="client_secret" placeholder="Client Secret" />}
                 />
-
+                <divider size="medium" />
+                <hint>
+                    <text style="bold">
+                        The following URL needs to be saved as a Sign-In Redirect URI in Okta:
+                    </text>
+                </hint>
+                <codeblock content={VACallbackURL} />
                 <input
                     label=""
                     hint=""
@@ -143,9 +149,6 @@ const configBlock = createComponent<OktaProps, OktaState, OktaAction, OktaRuntim
                         />
                     }
                 />
-                <divider size="medium" />
-                <text>The following URL needs to be saved as a Sign-In Redirect URI in Okta:</text>
-                <codeblock content={VACallbackURL} />
             </block>
         );
     },


### PR DESCRIPTION
Before
<img width="1169" alt="Screen Shot 2024-02-19 at 5 36 52 PM" src="https://github.com/GitbookIO/integrations/assets/140522517/cd32f9fd-67fb-4112-a6f9-7a1822829483">

After
<img width="1164" alt="Screen Shot 2024-02-19 at 5 36 08 PM" src="https://github.com/GitbookIO/integrations/assets/140522517/9ad41ab4-51d3-430f-bd7a-d8cc9c9490d2">
