### PR TITLE
Fix an issue where Edit on GitHub/GitLab links could be broken in published content.

### DIFF
--- a/.changeset/angry-knives-study.md
+++ b/.changeset/angry-knives-study.md
@@ -1,0 +1,6 @@
+---
+'@gitbook/integration-github': minor
+'@gitbook/integration-gitlab': minor
+---
+
+Fix an issue where GitBook was showing the wrong repository URL in published content.

--- a/integrations/github/src/sync.ts
+++ b/integrations/github/src/sync.ts
@@ -68,24 +68,24 @@ export async function triggerImport(
 
     logger.info(`Initiating an import from GitHub to GitBook space ${spaceInstallation.space}`);
 
-    const repoURL = getRepositoryUrl(config, true);
     const auth = await getRepositoryAuth(context, config);
+    const repoTreeURL = getGitTreeURL(config);
 
-    const urlWithAuth = new URL(repoURL);
+    const urlWithAuth = new URL(getRepositoryUrl(config, true));
     urlWithAuth.username = auth.username;
     urlWithAuth.password = auth.password;
 
     await api.spaces.importGitRepository(spaceInstallation.space, {
         url: urlWithAuth.toString(),
         ref: standalone?.ref || config.branch,
-        repoTreeURL: getGitTreeURL(config),
+        repoTreeURL,
         repoCommitURL: getGitCommitURL(config),
         repoProjectDirectory: config.projectDirectory,
         repoCacheID: config.key,
         force,
         timestamp: eventTimestamp && !force ? eventTimestamp.toISOString() : undefined,
         standalone: !!standalone,
-        ...(updateGitInfo ? { gitInfo: { provider: 'github', url: repoURL } } : {}),
+        ...(updateGitInfo ? { gitInfo: { provider: 'github', url: repoTreeURL } } : {}),
     });
 }
 
@@ -127,24 +127,24 @@ export async function triggerExport(
 
     const { data: revision } = await api.spaces.getCurrentRevision(spaceInstallation.space);
 
-    const repoURL = getRepositoryUrl(config, true);
     const auth = await getRepositoryAuth(context, config);
+    const repoTreeURL = getGitTreeURL(config);
 
-    const urlWithAuth = new URL(repoURL);
+    const urlWithAuth = new URL(getRepositoryUrl(config, true));
     urlWithAuth.username = auth.username;
     urlWithAuth.password = auth.password;
 
     await api.spaces.exportToGitRepository(spaceInstallation.space, {
         url: urlWithAuth.toString(),
         ref: config.branch,
-        repoTreeURL: getGitTreeURL(config),
+        repoTreeURL,
         repoCommitURL: getGitCommitURL(config),
         repoProjectDirectory: config.projectDirectory,
         repoCacheID: config.key,
         force,
         timestamp: eventTimestamp && !force ? eventTimestamp.toISOString() : undefined,
         commitMessage: getCommitMessageForRevision(config, revision),
-        ...(updateGitInfo ? { gitInfo: { provider: 'github', url: repoURL } } : {}),
+        ...(updateGitInfo ? { gitInfo: { provider: 'github', url: repoTreeURL } } : {}),
     });
 }
 

--- a/integrations/gitlab/src/sync.ts
+++ b/integrations/gitlab/src/sync.ts
@@ -67,24 +67,24 @@ export async function triggerImport(
 
     logger.info(`Initiating an import from GitLab to GitBook space ${spaceInstallation.space}`);
 
-    const repoURL = getRepositoryUrl(config, true);
+    const repoTreeURL = getGitTreeURL(config);
     const auth = await getRepositoryAuth(config);
 
-    const urlWithAuth = new URL(repoURL);
+    const urlWithAuth = new URL(getRepositoryUrl(config, true));
     urlWithAuth.username = auth.username;
     urlWithAuth.password = auth.password;
 
     await api.spaces.importGitRepository(spaceInstallation.space, {
         url: urlWithAuth.toString(),
         ref: standalone?.ref || config.branch,
-        repoTreeURL: getGitTreeURL(config),
+        repoTreeURL,
         repoCommitURL: getGitCommitURL(config),
         repoProjectDirectory: config.projectDirectory,
         repoCacheID: config.key,
         force,
         timestamp: eventTimestamp && !force ? eventTimestamp.toISOString() : undefined,
         standalone: !!standalone,
-        ...(updateGitInfo ? { gitInfo: { provider: 'gitlab', url: repoURL } } : {}),
+        ...(updateGitInfo ? { gitInfo: { provider: 'gitlab', url: repoTreeURL } } : {}),
     });
 }
 
@@ -126,24 +126,24 @@ export async function triggerExport(
 
     const { data: revision } = await api.spaces.getCurrentRevision(spaceInstallation.space);
 
-    const repoURL = getRepositoryUrl(config, true);
     const auth = await getRepositoryAuth(config);
+    const repoTreeURL = getGitTreeURL(config);
 
-    const urlWithAuth = new URL(repoURL);
+    const urlWithAuth = new URL(getRepositoryUrl(config, true));
     urlWithAuth.username = auth.username;
     urlWithAuth.password = auth.password;
 
     await api.spaces.exportToGitRepository(spaceInstallation.space, {
         url: urlWithAuth.toString(),
         ref: config.branch,
-        repoTreeURL: getGitTreeURL(config),
+        repoTreeURL,
         repoCommitURL: getGitCommitURL(config),
         repoProjectDirectory: config.projectDirectory,
         repoCacheID: config.key,
         force,
         timestamp: eventTimestamp && !force ? eventTimestamp.toISOString() : undefined,
         commitMessage: getCommitMessageForRevision(config, revision),
-        ...(updateGitInfo ? { gitInfo: { provider: 'gitlab', url: repoURL } } : {}),
+        ...(updateGitInfo ? { gitInfo: { provider: 'gitlab', url: repoTreeURL } } : {}),
     });
 }
 


### PR DESCRIPTION
We should always use the repoTreeURL when persisting Git repo information, and not the `.git` URL.