### PR TITLE
Add site:metadata:read scope to VA integrations

### DIFF
--- a/.changeset/weak-pumpkins-run.md
+++ b/.changeset/weak-pumpkins-run.md
@@ -1,0 +1,8 @@
+---
+'@gitbook/integration-va-auth0': patch
+'@gitbook/integration-va-azure': patch
+'@gitbook/integration-cognito': patch
+'@gitbook/integration-va-okta': patch
+---
+
+Add site:metadata:read scope to VA integrations

--- a/integrations/cognito/gitbook-manifest.yaml
+++ b/integrations/cognito/gitbook-manifest.yaml
@@ -10,6 +10,7 @@ script: ./src/index.tsx
 scopes:
     - space:metadata:read
     - space:visitor:auth
+    - site:metadata:read
     - site:visitor:auth
     - space:content:read
 organization: gitbook
@@ -28,4 +29,6 @@ categories:
     - other
 configurations:
     space:
+        componentId: config
+    site:
         componentId: config

--- a/integrations/va-auth0/gitbook-manifest.yaml
+++ b/integrations/va-auth0/gitbook-manifest.yaml
@@ -1,4 +1,4 @@
-name: VA-Auth0
+name: va-auth0
 title: Auth0
 icon: ./assets/icon.png
 previewImages:
@@ -9,6 +9,7 @@ script: ./src/index.tsx
 scopes:
     - space:metadata:read
     - space:visitor:auth
+    - site:metadata:read
     - site:visitor:auth
     - space:content:read
 organization: d8f63b60-89ae-11e7-8574-5927d48c4877

--- a/integrations/va-auth0/gitbook-manifest.yaml
+++ b/integrations/va-auth0/gitbook-manifest.yaml
@@ -1,4 +1,4 @@
-name: va-auth0
+name: VA-Auth0
 title: Auth0
 icon: ./assets/icon.png
 previewImages:

--- a/integrations/va-azure/gitbook-manifest.yaml
+++ b/integrations/va-azure/gitbook-manifest.yaml
@@ -10,6 +10,7 @@ script: ./src/index.tsx
 scopes:
     - space:metadata:read
     - space:visitor:auth
+    - site:metadata:read
     - site:visitor:auth
     - space:content:read
 organization: d8f63b60-89ae-11e7-8574-5927d48c4877

--- a/integrations/va-okta/gitbook-manifest.yaml
+++ b/integrations/va-okta/gitbook-manifest.yaml
@@ -9,6 +9,7 @@ script: ./src/index.tsx
 scopes:
     - space:metadata:read
     - space:visitor:auth
+    - site:metadata:read
     - site:visitor:auth
     - space:content:read
 organization: d8f63b60-89ae-11e7-8574-5927d48c4877

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
             }
         },
         "integrations/cognito": {
-            "version": "0.0.1",
+            "name": "@gitbook/integration-cognito",
+            "version": "0.0.3",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*",
@@ -79,7 +80,7 @@
         },
         "integrations/fathom": {
             "name": "@gitbook/integration-fathom",
-            "version": "0.0.4",
+            "version": "0.0.5",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*"
@@ -116,7 +117,7 @@
         },
         "integrations/github": {
             "name": "@gitbook/integration-github",
-            "version": "0.1.1",
+            "version": "0.2.0",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*",
@@ -203,7 +204,7 @@
         },
         "integrations/gitlab": {
             "name": "@gitbook/integration-gitlab",
-            "version": "0.0.15",
+            "version": "0.1.0",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*",
@@ -252,7 +253,7 @@
         },
         "integrations/googleanalytics": {
             "name": "@gitbook/integration-googleanalytics",
-            "version": "0.1.3",
+            "version": "0.1.4",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*"
@@ -263,7 +264,7 @@
         },
         "integrations/heap": {
             "name": "@gitbook/integration-heap",
-            "version": "0.1.3",
+            "version": "0.1.4",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*"
@@ -274,7 +275,7 @@
         },
         "integrations/hotjar": {
             "name": "@gitbook/integration-hotjar",
-            "version": "0.1.3",
+            "version": "0.1.4",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*"
@@ -296,7 +297,7 @@
         },
         "integrations/intercom": {
             "name": "@gitbook/integration-intercom",
-            "version": "0.0.4",
+            "version": "0.0.5",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*"
@@ -626,7 +627,7 @@
         },
         "integrations/mixpanel": {
             "name": "@gitbook/integration-mixpanel",
-            "version": "0.0.3",
+            "version": "0.0.4",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*"
@@ -637,7 +638,7 @@
         },
         "integrations/plausible": {
             "name": "@gitbook/integration-plausible",
-            "version": "0.1.3",
+            "version": "0.1.4",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*"
@@ -648,7 +649,7 @@
         },
         "integrations/posthog": {
             "name": "@gitbook/integration-posthog",
-            "version": "0.0.6",
+            "version": "0.0.7",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*"
@@ -787,7 +788,7 @@
         },
         "integrations/slack": {
             "name": "@gitbook/integration-slack",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "dependencies": {
                 "@gitbook/runtime": "*",
                 "itty-router": "^2.6.1",
@@ -818,7 +819,7 @@
         },
         "integrations/va-auth0": {
             "name": "@gitbook/integration-va-auth0",
-            "version": "0.0.5",
+            "version": "0.0.6",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*",
@@ -831,7 +832,7 @@
         },
         "integrations/va-azure": {
             "name": "@gitbook/integration-va-azure",
-            "version": "0.0.5",
+            "version": "0.0.6",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*",
@@ -844,7 +845,7 @@
         },
         "integrations/va-okta": {
             "name": "@gitbook/integration-va-okta",
-            "version": "0.0.6",
+            "version": "0.0.7",
             "dependencies": {
                 "@gitbook/api": "*",
                 "@gitbook/runtime": "*",
@@ -13971,7 +13972,7 @@
         },
         "packages/api": {
             "name": "@gitbook/api",
-            "version": "0.44.0",
+            "version": "0.46.0",
             "dependencies": {
                 "event-iterator": "^2.0.0",
                 "eventsource-parser": "^1.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -788,7 +788,7 @@
         },
         "integrations/slack": {
             "name": "@gitbook/integration-slack",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "dependencies": {
                 "@gitbook/runtime": "*",
                 "itty-router": "^2.6.1",


### PR DESCRIPTION
This PR aims to add the site:metadata:read scope to VA integrations to allow them to perform `getSiteById` API calls.