### PR TITLE
Add and enforce HTTPS for domains in VA configurations

### DIFF
--- a/.changeset/fresh-guests-sit.md
+++ b/.changeset/fresh-guests-sit.md
@@ -1,0 +1,6 @@
+---
+'@gitbook/integration-va-auth0': patch
+'@gitbook/integration-va-okta': patch
+---
+
+Add and enforce HTTPS for domains in VA configurations

--- a/integrations/va-auth0/src/index.tsx
+++ b/integrations/va-auth0/src/index.tsx
@@ -39,6 +39,16 @@ type Auth0Props = {
 
 export type Auth0Action = { action: 'save.config' };
 
+const getDomainWithHttps = (url: string): string => {
+    if (url.startsWith('https://')) {
+        return url;
+    } else if (url.startsWith('http://')) {
+        return url.replace('http', 'https');
+    } else {
+        return `https://${url}`;
+    }
+};
+
 const configBlock = createComponent<Auth0Props, Auth0State, Auth0Action, Auth0RuntimeContext>({
     componentId: 'config',
     initialState: (props) => {
@@ -61,7 +71,7 @@ const configBlock = createComponent<Auth0Props, Auth0State, Auth0Action, Auth0Ru
                     ...siteOrSpaceInstallation.configuration,
                     client_id: element.state.client_id,
                     client_secret: element.state.client_secret,
-                    issuer_base_url: element.state.issuer_base_url,
+                    issuer_base_url: getDomainWithHttps(element.state.issuer_base_url),
                 };
 
                 if ('site' in siteOrSpaceInstallation) {

--- a/integrations/va-okta/src/index.tsx
+++ b/integrations/va-okta/src/index.tsx
@@ -39,6 +39,16 @@ type OktaProps = {
 
 export type OktaAction = { action: 'save.config' };
 
+const getDomainWithHttps = (url: string): string => {
+    if (url.startsWith('https://')) {
+        return url;
+    } else if (url.startsWith('http://')) {
+        return url.replace('http', 'https');
+    } else {
+        return `https://${url}`;
+    }
+};
+
 const configBlock = createComponent<OktaProps, OktaState, OktaAction, OktaRuntimeContext>({
     componentId: 'config',
     initialState: (props) => {
@@ -60,7 +70,7 @@ const configBlock = createComponent<OktaProps, OktaState, OktaAction, OktaRuntim
                     ...siteOrSpaceInstallation.configuration,
                     client_id: element.state.client_id,
                     client_secret: element.state.client_secret,
-                    okta_domain: element.state.okta_domain,
+                    okta_domain: getDomainWithHttps(element.state.okta_domain),
                 };
                 if ('site' in siteOrSpaceInstallation) {
                     await api.integrations.updateIntegrationSiteInstallation(


### PR DESCRIPTION
Fixes issues where Auth0 users had to have the `https://` prefix for their domains. Now, for both Okta and Auth0, it doesn't matter whether the user has provided the prefix or not. We will simply default to `https://`

Cognito doesn't have this issue and Azure doesn't use domains for the integration's configuration