### PR TITLE
Disable client_storage on gtag when cookies consent is no/undefined

### DIFF
--- a/.changeset/moody-colts-taste.md
+++ b/.changeset/moody-colts-taste.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-googleanalytics': patch
+---
+
+Disable gtag storage when cookies consent is no

--- a/integrations/googleanalytics/src/script.raw.js
+++ b/integrations/googleanalytics/src/script.raw.js
@@ -57,6 +57,9 @@
             send_page_view: false,
             anonymize_ip: true,
             groups: 'tracking_views',
+            ...(disableCookies ? {
+                client_storage: 'none',
+            } : {})
         });
         triggerView(win);
 


### PR DESCRIPTION
We were previously using the https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced#set_consent_defaults guide, but it looks like it's not sufficient for Gtag/GA not to store any cookie.