### PR TITLE
Update integrations to use site configuration as only variable for configurations

### DIFF
--- a/.changeset/small-phones-clean.md
+++ b/.changeset/small-phones-clean.md
@@ -1,0 +1,16 @@
+---
+'@gitbook/integration-googleanalytics': minor
+'@gitbook/integration-helpscout': minor
+'@gitbook/integration-plausible': minor
+'@gitbook/integration-intercom': minor
+'@gitbook/integration-mixpanel': minor
+'@gitbook/integration-posthog': minor
+'@gitbook/integration-fathom': minor
+'@gitbook/integration-hotjar': minor
+'@gitbook/integration-crisp': minor
+'@gitbook/integration-koala': minor
+'@gitbook/integration-heap': minor
+'@gitbook/integration-reo.dev': minor
+---
+
+Updates all packages to remove the spaces configuration, and rely on the now used site configuration instead. Also removes instances of the spaces variable where applicable

--- a/integrations/crisp/gitbook-manifest.yaml
+++ b/integrations/crisp/gitbook-manifest.yaml
@@ -37,14 +37,6 @@ summary: |
 categories:
     - analytics
 configurations:
-    space:
-        properties:
-            tracking_id:
-                type: string
-                title: Crisp Site ID
-                description: Available in the URL from your Crisp dashboard
-        required:
-            - tracking_id
     site:
         properties:
             tracking_id:

--- a/integrations/crisp/src/index.ts
+++ b/integrations/crisp/src/index.ts
@@ -20,9 +20,7 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     event,
     { environment }: CrispRuntimeContext
 ) => {
-    const trackingId =
-        environment.siteInstallation?.configuration?.tracking_id ??
-        environment.spaceInstallation?.configuration?.tracking_id;
+    const trackingId = environment.siteInstallation?.configuration?.tracking_id;
     if (!trackingId) {
         throw new Error(
             `The Crisp Website ID is missing from the configuration (ID: ${

--- a/integrations/fathom/gitbook-manifest.yaml
+++ b/integrations/fathom/gitbook-manifest.yaml
@@ -36,14 +36,6 @@ summary: |
 categories:
     - analytics
 configurations:
-    space:
-        properties:
-            site_id:
-                type: string
-                title: Site ID
-                description: Look for this in your Fathom analytics account
-        required:
-            - site_id
     site:
         properties:
             site_id:

--- a/integrations/fathom/src/index.ts
+++ b/integrations/fathom/src/index.ts
@@ -20,9 +20,7 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     event,
     { environment }: FathomRuntimeContext
 ) => {
-    const siteId =
-        environment.siteInstallation?.configuration?.site_id ??
-        environment.spaceInstallation?.configuration?.site_id;
+    const siteId = environment.siteInstallation?.configuration?.site_id;
 
     if (!siteId) {
         return;

--- a/integrations/googleanalytics/gitbook-manifest.yaml
+++ b/integrations/googleanalytics/gitbook-manifest.yaml
@@ -51,14 +51,6 @@ summary: |
 categories:
     - analytics
 configurations:
-    space:
-        properties:
-            tracking_id:
-                type: string
-                title: Tracking ID
-                description: Look for this in your Google Analytics account.
-        required:
-            - tracking_id
     site:
         properties:
             tracking_id:

--- a/integrations/googleanalytics/src/index.ts
+++ b/integrations/googleanalytics/src/index.ts
@@ -20,9 +20,7 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     event,
     { environment }: GARuntimeContext
 ) => {
-    const trackingId =
-        environment.siteInstallation?.configuration?.tracking_id ??
-        environment.spaceInstallation?.configuration?.tracking_id;
+    const trackingId = environment.siteInstallation?.configuration?.tracking_id;
     if (!trackingId) {
         return;
     }

--- a/integrations/heap/gitbook-manifest.yaml
+++ b/integrations/heap/gitbook-manifest.yaml
@@ -40,14 +40,6 @@ summary: |
 categories:
     - analytics
 configurations:
-    space:
-        properties:
-            tracking_id:
-                type: string
-                title: Tracking ID
-                description: Available in Heap's Web installation flow `heap.load("YOUR_ID_IS_HERE")`
-        required:
-            - tracking_id
     site:
         properties:
             tracking_id:

--- a/integrations/heap/src/index.ts
+++ b/integrations/heap/src/index.ts
@@ -20,9 +20,7 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     event,
     { environment }: HeapRuntimeContext
 ) => {
-    const trackingId =
-        environment.siteInstallation?.configuration?.tracking_id ??
-        environment.spaceInstallation?.configuration?.tracking_id;
+    const trackingId = environment.siteInstallation?.configuration?.tracking_id;
     if (!trackingId) {
         throw new Error(
             `The Heap environment ID is missing from the configuration (ID: ${

--- a/integrations/helpscout/gitbook-manifest.yaml
+++ b/integrations/helpscout/gitbook-manifest.yaml
@@ -30,14 +30,6 @@ secrets: {}
 contentSecurityPolicy:
     script-src: https://beacon-v2.helpscout.net;
 configurations:
-    space:
-        properties:
-            helpscout_id:
-                type: string
-                title: HelpScout ID
-                description: Your HelpScout integration ID.
-        required:
-            - helpscout_id
     site:
         properties:
             helpscout_id:

--- a/integrations/helpscout/src/index.tsx
+++ b/integrations/helpscout/src/index.tsx
@@ -20,10 +20,7 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     event,
     { environment }: HelpScoutRuntimeContext
 ) => {
-    const helpscoutID =
-        environment.siteInstallation?.configuration?.helpscout_id ??
-        environment.spaceInstallation?.configuration?.helpscout_id ??
-        'HelpScout ID not configured';
+    const helpscoutID = environment.siteInstallation?.configuration?.helpscout_id;
 
     if (!helpscoutID) {
         return;

--- a/integrations/helpscout/src/index.tsx
+++ b/integrations/helpscout/src/index.tsx
@@ -21,8 +21,8 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     { environment }: HelpScoutRuntimeContext
 ) => {
     const helpscoutID =
-        environment.spaceInstallation?.configuration?.helpscout_id ??
         environment.siteInstallation?.configuration?.helpscout_id ??
+        environment.spaceInstallation?.configuration?.helpscout_id ??
         'HelpScout ID not configured';
 
     if (!helpscoutID) {

--- a/integrations/hotjar/gitbook-manifest.yaml
+++ b/integrations/hotjar/gitbook-manifest.yaml
@@ -32,14 +32,6 @@ summary: |
 categories:
     - analytics
 configurations:
-    space:
-        properties:
-            tracking_id:
-                type: string
-                title: Hotjar Site ID
-                description: Available in Hotjar's Organization & sites section
-        required:
-            - tracking_id
     site:
         properties:
             tracking_id:

--- a/integrations/hotjar/src/index.ts
+++ b/integrations/hotjar/src/index.ts
@@ -20,9 +20,7 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     event,
     { environment }: HotjarRuntimeContext
 ) => {
-    const trackingId =
-        environment.siteInstallation?.configuration?.tracking_id ??
-        environment.spaceInstallation?.configuration?.tracking_id;
+    const trackingId = environment.siteInstallation?.configuration?.tracking_id;
     if (!trackingId) {
         throw new Error(
             `The Hotjar Site ID is missing from the configuration (ID: ${

--- a/integrations/intercom/gitbook-manifest.yaml
+++ b/integrations/intercom/gitbook-manifest.yaml
@@ -74,14 +74,6 @@ summary: |
 categories:
     - analytics
 configurations:
-    space:
-        properties:
-            app_id:
-                type: string
-                title: Application ID
-                description: You can find it in your Intercom account, under the "Installation" section of the "Settings" page.
-        required:
-            - app_id
     site:
         properties:
             app_id:

--- a/integrations/intercom/src/index.ts
+++ b/integrations/intercom/src/index.ts
@@ -20,9 +20,7 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     event,
     { environment }: IntercomRuntimeContext
 ) => {
-    const appId =
-        environment.siteInstallation?.configuration?.app_id ??
-        environment.spaceInstallation?.configuration?.app_id;
+    const appId = environment.siteInstallation?.configuration?.app_id;
 
     if (!appId) {
         return;

--- a/integrations/koala/gitbook-manifest.yaml
+++ b/integrations/koala/gitbook-manifest.yaml
@@ -30,14 +30,6 @@ secrets: {}
 contentSecurityPolicy:
     script-src: cdn.getkoala.com https://*.getkoala.com;
 configurations:
-    space:
-        properties:
-            koala_key:
-                type: string
-                title: Koala Key
-                description: Available in Koala snippet https://cdn.getkoala.com/v1/<pk_xxxxxxxxxxxxxxxxxxx>/sdk.js
-        required:
-            - koala_key
     site:
         properties:
             koala_key:

--- a/integrations/koala/src/index.tsx
+++ b/integrations/koala/src/index.tsx
@@ -21,8 +21,8 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     { environment }: KoalaRuntimeContext
 ) => {
     const koalaId =
-        environment.spaceInstallation?.configuration?.koala_key ??
         environment.siteInstallation?.configuration?.koala_key ??
+        environment.spaceInstallation?.configuration?.koala_key ??
         'Koala Key not configured';
 
     if (!koalaId) {

--- a/integrations/koala/src/index.tsx
+++ b/integrations/koala/src/index.tsx
@@ -20,10 +20,7 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     event,
     { environment }: KoalaRuntimeContext
 ) => {
-    const koalaId =
-        environment.siteInstallation?.configuration?.koala_key ??
-        environment.spaceInstallation?.configuration?.koala_key ??
-        'Koala Key not configured';
+    const koalaId = environment.siteInstallation?.configuration?.koala_key;
 
     if (!koalaId) {
         return;

--- a/integrations/mixpanel/gitbook-manifest.yaml
+++ b/integrations/mixpanel/gitbook-manifest.yaml
@@ -27,14 +27,6 @@ summary: |
 categories:
     - analytics
 configurations:
-    space:
-        properties:
-            project_token:
-                type: string
-                title: Project Token
-                description: Available in Mixpanel's Project Settings section
-        required:
-            - project_token
     site:
         properties:
             project_token:

--- a/integrations/mixpanel/src/index.ts
+++ b/integrations/mixpanel/src/index.ts
@@ -20,9 +20,8 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     event,
     { environment }: MixpanelRuntimeContext
 ) => {
-    const projectToken =
-        environment.siteInstallation?.configuration?.project_token ??
-        environment.spaceInstallation?.configuration?.project_token;
+    const projectToken = environment.siteInstallation?.configuration?.project_token;
+
     if (!projectToken) {
         throw new Error(
             `The Mixpanel Project Token is missing from the configuration (ID: ${

--- a/integrations/plausible/gitbook-manifest.yaml
+++ b/integrations/plausible/gitbook-manifest.yaml
@@ -35,18 +35,6 @@ summary: |
 categories:
     - analytics
 configurations:
-    space:
-        properties:
-            domain:
-                type: string
-                title: Domain
-                description: The domain URL you configured for this Plausible website.
-            api:
-                type: string
-                title: Self-hosted API
-                description: When self-hosting, configure the url of the instance API (empty when using plausible.io).
-        required:
-            - domain
     site:
         properties:
             domain:

--- a/integrations/plausible/src/index.ts
+++ b/integrations/plausible/src/index.ts
@@ -21,12 +21,8 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     event,
     { environment }: PlausibleRuntimeContext
 ) => {
-    const domain =
-        environment.siteInstallation?.configuration?.domain ??
-        environment.spaceInstallation?.configuration?.domain;
-    const api =
-        environment.siteInstallation?.configuration?.api ??
-        (environment.spaceInstallation?.configuration?.api || '');
+    const domain = environment.siteInstallation?.configuration?.domain;
+    const api = environment.siteInstallation?.configuration?.api || '';
     if (!domain) {
         return;
     }

--- a/integrations/posthog/gitbook-manifest.yaml
+++ b/integrations/posthog/gitbook-manifest.yaml
@@ -33,22 +33,6 @@ summary: |
 categories:
     - analytics
 configurations:
-    space:
-        properties:
-            projectApiKey:
-                type: string
-                title: Project API Key
-                description: Available in the PostHog installation snippet, as the first parameter, starting with 'phc_'
-            instanceAddress:
-                type: string
-                title: Instance address
-                description: Depends on your PostHog installation's location (either EU, or US)
-                enum:
-                    - EU
-                    - US
-        required:
-            - projectApiKey
-            - instanceAddress
     site:
         properties:
             projectApiKey:

--- a/integrations/posthog/src/index.ts
+++ b/integrations/posthog/src/index.ts
@@ -25,12 +25,8 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
         EU: 'https://eu.posthog.com',
         US: 'https://app.posthog.com',
     };
-    const projectApiKey =
-        environment.siteInstallation?.configuration?.projectApiKey ??
-        environment.spaceInstallation?.configuration?.projectApiKey;
-    const instanceAddress =
-        environment.siteInstallation?.configuration?.instanceAddress ??
-        environment.spaceInstallation?.configuration?.instanceAddress;
+    const projectApiKey = environment.siteInstallation?.configuration?.projectApiKey;
+    const instanceAddress = environment.siteInstallation?.configuration?.instanceAddress;
     if (!projectApiKey) {
         throw new Error(
             `The PostHog project API key is missing from the space configuration (ID: ${

--- a/integrations/reo/gitbook-manifest.yaml
+++ b/integrations/reo/gitbook-manifest.yaml
@@ -33,14 +33,6 @@ summary: |
 categories:
     - analytics
 configurations:
-    space:
-        properties:
-            tracking_id:
-                type: string
-                title: Client ID
-                description: Available in Reo.dev's Integration -> Documentation section
-        required:
-            - tracking_id
     site:
         properties:
             tracking_id:

--- a/integrations/reo/src/index.ts
+++ b/integrations/reo/src/index.ts
@@ -20,9 +20,8 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     event,
     { environment }: ReoDotDevRuntimeContext
 ) => {
-    const trackingId =
-        environment.siteInstallation?.configuration?.tracking_id ??
-        environment.spaceInstallation?.configuration?.tracking_id;
+    const trackingId = environment.siteInstallation?.configuration?.tracking_id;
+
     if (!trackingId) {
         throw new Error(
             `The Reo.Dev tracking ID is missing from the configuration (ID: ${event.spaceId}).`


### PR DESCRIPTION
This PR updates analytics integrations to default and use the main site configuration variable instead of the space variable in some cases. 