### PR TITLE
Fix RunLLM integration's default value for disable-ask-a-person

### DIFF
--- a/integrations/runllm-widget/src/index.tsx
+++ b/integrations/runllm-widget/src/index.tsx
@@ -45,7 +45,7 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     const keyboardShortcut = config?.keyboard_shortcut ?? '';
     const communityType = config?.community_type ?? '';
     const communityUrl = config?.community_url ?? '';
-    const disableAskAPerson = config?.disable_ask_a_person ? 'true' : '';
+    const disableAskAPerson = config?.disable_ask_a_person ? 'false' : '';
 
     return new Response(
         script


### PR DESCRIPTION
This PR fixes RunLLM integration's default value for disable-ask-a-person settings. This value should be false instead of true when the user does not specify the value in the site / space configuration.