### PR TITLE
Add support for new render output types

### DIFF
--- a/.changeset/yellow-sheep-jump.md
+++ b/.changeset/yellow-sheep-jump.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/runtime': minor
+---
+
+Add support for new render output types

--- a/packages/runtime/src/components.ts
+++ b/packages/runtime/src/components.ts
@@ -67,8 +67,8 @@ export function createComponent<
      * Initial state of the component.
      */
     initialState?:
-    | State
-    | ((props: Props, renderContext: ContentKitContext, context: Context) => State);
+        | State
+        | ((props: Props, renderContext: ContentKitContext, context: Context) => State);
 
     /**
      * Callback to handle a dispatched action.
@@ -122,9 +122,9 @@ export function createComponent<
                         'Content-Type': 'application/json',
                         ...(cache
                             ? {
-                                // @ts-ignore - I'm not sure how to fix this one with TS
-                                'Cache-Control': `max-age=${cache.maxAge}`,
-                            }
+                                  // @ts-ignore - I'm not sure how to fix this one with TS
+                                  'Cache-Control': `max-age=${cache.maxAge}`,
+                              }
                             : {}),
                     },
                 });


### PR DESCRIPTION
This update tweaks the runtime to handle new render output types. Now, the action function can either return:

 - `element`: when the component is still in its lifecycle.
 - `complete`: signaling the component has finished its lifecycle and providing an optional return value. 
