### PR TITLE
Don't fail to render Jira embed if configuration is incomplete

### DIFF
--- a/.changeset/cold-weeks-notice.md
+++ b/.changeset/cold-weeks-notice.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-jira': minor
+---
+
+Prevent Jira embed render to fail when its configuration is incomplete

--- a/integrations/jira/package.json
+++ b/integrations/jira/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@gitbook/integration-jira",
+    "version": "0.1.0",
     "private": true,
     "scripts": {
         "typecheck": "tsc --noEmit",

--- a/integrations/jira/src/index.tsx
+++ b/integrations/jira/src/index.tsx
@@ -58,15 +58,23 @@ const embedBlock = createComponent<Props, {}, void, IntegrationContext>({
         element.setCache({ maxAge: 0 });
 
         const { url: rawUrl } = element.props;
+        const { environment } = context;
+        const configuration = environment.installation?.configuration as JiraConfiguration;
+        if (!configuration.oauth_credentials || !configuration.sites) {
+            return (
+                <block>
+                    <card title="Integration misconfigured">
+                        <text>{rawUrl ?? ''}</text>
+                    </card>
+                </block>
+            );
+        }
 
         const url = rawUrl ? new URL(rawUrl) : null;
         const parts = url?.pathname.split('/');
         const key = parts ? parts[parts.length - 1] : null;
 
-        const { environment } = context;
-        const configuration = environment.installation?.configuration as JiraConfiguration;
-
-        if (!url || !key || !configuration.oauth_credentials) {
+        if (!url || !key) {
             return (
                 <block>
                     <card title="Not Found">
@@ -76,7 +84,7 @@ const embedBlock = createComponent<Props, {}, void, IntegrationContext>({
             );
         }
 
-        const site = configuration.sites?.find((site) => url.toString().startsWith(site.url));
+        const site = configuration.sites.find((site) => url.toString().startsWith(site.url));
         if (!site) {
             // JIRA site not part of this installation
             return (

--- a/integrations/jira/src/index.tsx
+++ b/integrations/jira/src/index.tsx
@@ -23,8 +23,8 @@ interface Site {
 }
 
 type JiraConfiguration = {
-    sites: Site[];
-    oauth_credentials: OAuthConfiguration;
+    sites?: Site[];
+    oauth_credentials?: OAuthConfiguration;
 };
 
 type IntegrationEnvironment = RuntimeEnvironment<JiraConfiguration>;
@@ -63,7 +63,10 @@ const embedBlock = createComponent<Props, {}, void, IntegrationContext>({
         const parts = url?.pathname.split('/');
         const key = parts ? parts[parts.length - 1] : null;
 
-        if (!url || !key) {
+        const { environment } = context;
+        const configuration = environment.installation?.configuration as JiraConfiguration;
+
+        if (!url || !key || !configuration.oauth_credentials) {
             return (
                 <block>
                     <card title="Not Found">
@@ -73,10 +76,7 @@ const embedBlock = createComponent<Props, {}, void, IntegrationContext>({
             );
         }
 
-        const { environment } = context;
-        const configuration = environment.installation?.configuration as JiraConfiguration;
-        const site = configuration.sites.find((site) => url.toString().startsWith(site.url));
-
+        const site = configuration.sites?.find((site) => url.toString().startsWith(site.url));
         if (!site) {
             // JIRA site not part of this installation
             return (


### PR DESCRIPTION
This PR makes the Jira integration safer by checking for the configuration data before trying to access them while rendering.
If any of the configuration data is missing, it renders a block with a `Integration misconfigured` text.