### PR TITLE
Don't catch router errors to allow them to be caught and processed in GitHub and GitLab integrations

### DIFF
--- a/.changeset/moody-nails-raise.md
+++ b/.changeset/moody-nails-raise.md
@@ -1,0 +1,6 @@
+---
+'@gitbook/integration-github': patch
+'@gitbook/integration-gitlab': patch
+---
+
+Don't catch router errors to allow them to be caught and processed in GitHub and GitLab integrations

--- a/integrations/github/src/index.ts
+++ b/integrations/github/src/index.ts
@@ -364,10 +364,7 @@ const handleFetchEvent: FetchEventCallback<GithubRuntimeContext> = async (reques
         });
     });
 
-    const response = (await router.handle(request, context).catch((err) => {
-        logger.error(`error handling request ${err.message} ${err.stack}`);
-        return error(err);
-    })) as Response | undefined;
+    const response = (await router.handle(request, context)) as Response | undefined;
 
     if (!response) {
         return new Response(`No route matching ${request.method} ${request.url}`, {

--- a/integrations/gitlab/src/index.ts
+++ b/integrations/gitlab/src/index.ts
@@ -283,10 +283,7 @@ const handleFetchEvent: FetchEventCallback<GitLabRuntimeContext> = async (reques
         });
     });
 
-    const response = (await router.handle(request, context).catch((err) => {
-        logger.error(`error handling request ${err.message} ${err.stack}`);
-        return error(err);
-    })) as Response | undefined;
+    const response = (await router.handle(request, context)) as Response | undefined;
 
     if (!response) {
         return new Response(`No route matching ${request.method} ${request.url}`, {


### PR DESCRIPTION
Otherwise the errors are currently swallowed and the runtime actually returns a 500 error, even for exposable ones.