### PR TITLE
Increase the min length of state param to 10 in OIDC integration

### DIFF
--- a/.changeset/silver-clouds-bow.md
+++ b/.changeset/silver-clouds-bow.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-oidc': patch
+---
+
+Increase the min length of state to 10 chars

--- a/integrations/oidc/src/index.tsx
+++ b/integrations/oidc/src/index.tsx
@@ -401,7 +401,7 @@ export default createIntegration({
         url.searchParams.append('response_type', 'code');
         url.searchParams.append('redirect_uri', `${installationURL}/visitor-auth/response`);
         url.searchParams.append('scope', scope.toLowerCase());
-        url.searchParams.append('state', `state-${location}`);
+        url.searchParams.append('state', `oidcstate-${location}`);
 
         return Response.redirect(url.toString());
     },


### PR DESCRIPTION
Some IdPs enforce a min 8 character length for the state parameter. This changes the state param's min length from 6 to 10