### PR TITLE
Add completion_url and enum to the integration configuration manifest.

### DIFF
--- a/packages/cli/src/manifest.ts
+++ b/packages/cli/src/manifest.ts
@@ -33,6 +33,8 @@ const IntegrationManifestSchemaConfiguration = z.object({
             JSONSchemaBaseSchema.extend({
                 type: z.literal('string'),
                 default: z.string().optional(),
+                completion_url: z.string().optional(),
+                enum: z.array(z.string()).optional(),
             }),
             JSONSchemaBaseSchema.extend({
                 type: z.literal('number'),


### PR DESCRIPTION
Missing these properties meant they weren't passed to the API.
