### PR TITLE
Added support for posthog identity api

### DIFF
--- a/integrations/posthog/gitbook-manifest.yaml
+++ b/integrations/posthog/gitbook-manifest.yaml
@@ -44,6 +44,11 @@ configurations:
                 enum:
                     - EU
                     - US
+            identifyUsers:
+                type: boolean
+                title: Identify Users
+                description: Enable user identification in PostHog to track individual user behavior
+                default: false
         required:
             - projectApiKey
             - instanceAddress

--- a/integrations/posthog/src/index.ts
+++ b/integrations/posthog/src/index.ts
@@ -13,13 +13,14 @@ type PostHogRuntimeContext = RuntimeContext<
         {
             projectApiKey?: string;
             instanceAddress?: 'EU' | 'US';
+            identifyUsers?: boolean;
         }
     >
 >;
 
 export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     event,
-    { environment }: PostHogRuntimeContext,
+    { environment, currentUser }: PostHogRuntimeContext,
 ) => {
     const instancesURLs = {
         EU: 'https://eu.posthog.com',
@@ -27,6 +28,8 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     };
     const projectApiKey = environment.siteInstallation?.configuration?.projectApiKey;
     const instanceAddress = environment.siteInstallation?.configuration?.instanceAddress;
+    const identifyUsers = environment.siteInstallation?.configuration?.identifyUsers ?? false;
+
     if (!projectApiKey) {
         throw new Error(
             `The PostHog project API key is missing from the space configuration (ID: ${
@@ -42,17 +45,27 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
         );
     }
 
-    return new Response(
-        (script as string)
-            .replace('<ph_project_api_key>', projectApiKey)
-            .replace('<ph_instance_address>', instancesURLs[instanceAddress]),
-        {
-            headers: {
-                'Content-Type': 'application/javascript',
-                'Cache-Control': 'max-age=604800',
-            },
+    let scriptContent = script as string;
+    scriptContent = scriptContent.replace('<ph_project_api_key>', projectApiKey);
+    scriptContent = scriptContent.replace('<ph_instance_address>', instancesURLs[instanceAddress]);
+
+    // Add user identification after PostHog initialization if enabled
+    if (identifyUsers && currentUser) {
+        scriptContent += `
+posthog.identify("${currentUser.id}", {
+    name: "${currentUser.displayName || ''}",
+    email: "${currentUser.email || ''}",
+    avatar: "${currentUser.photoURL || ''}"
+});
+`;
+    }
+
+    return new Response(scriptContent, {
+        headers: {
+            'Content-Type': 'application/javascript',
+            'Cache-Control': 'max-age=604800',
         },
-    );
+    });
 };
 
 export default createIntegration<PostHogRuntimeContext>({


### PR DESCRIPTION
# Add User Identification to PostHog Integration

## Overview
This PR adds user identification capabilities to the PostHog integration, allowing for better user tracking and analytics by sending authenticated user data to PostHog.

## Changes
- Added user identification logic to append user data after PostHog initialization
- Sends user ID, name, email, and avatar URL to PostHog when available
- Added `identifyUsers` configuration option to control the feature
- Updated manifest to include new configuration option

## Documentation
The integration will now identify users in PostHog when enabled, allowing for:
- User-specific analytics and tracking
- Better understanding of user behavior
- Cross-session user tracking
- Enhanced segmentation capabilities

## Related Issues
Closes #809 