### PR TITLE
Fix an issue where certain integrations which rely on iframes could render incorrectly in the preview.

### DIFF
--- a/.changeset/cold-tires-rule.md
+++ b/.changeset/cold-tires-rule.md
@@ -1,0 +1,7 @@
+---
+'@gitbook/integration-marketo': patch
+'@gitbook/integration-mermaid': patch
+'@gitbook/integration-runkit': patch
+---
+
+Fix an issue where certain integrations which rely on iframes could render incorrectly in the preview.

--- a/integrations/marketo/webframe/src/webframe.ts
+++ b/integrations/marketo/webframe/src/webframe.ts
@@ -1,4 +1,4 @@
-const gitbookWebFrame = window.top;
+const gitbookWebFrame = window.parent;
 const params = new URLSearchParams(window.location.search);
 const formId = params.get('formId');
 const munchkinId = params.get('munchkinId');

--- a/integrations/mermaid/src/index.tsx
+++ b/integrations/mermaid/src/index.tsx
@@ -126,7 +126,7 @@ export default createIntegration({
                         }
 
                         function sendAction(action) {
-                            window.top.postMessage(
+                            window.parent.postMessage(
                                 {
                                     action,
                                 },

--- a/integrations/runkit/webframe/src/webframe.ts
+++ b/integrations/runkit/webframe/src/webframe.ts
@@ -1,4 +1,4 @@
-const gitbookWebFrame = window.top;
+const gitbookWebFrame = window.parent;
 
 let readOnly = false;
 let runKitNotebook: NotebookEmbed | null = null;


### PR DESCRIPTION
`window.parent` should be used as the one managing the iframe.