### PR TITLE
Update regex github.ts of GitHub Files integration to also capture dots for repo names

### DIFF
--- a/integrations/github-files/src/github.ts
+++ b/integrations/github-files/src/github.ts
@@ -7,8 +7,8 @@ export interface GithubProps {
 
 const splitGithubUrl = (url: string) => {
     const permalinkRegex =
-        /^https?:\/\/github\.com\/([\w-]+)\/([\w-]+)\/blob\/([a-f0-9]+)\/(.+?)#(.+)$/;
-    const wholeFileRegex = /^https?:\/\/github\.com\/([\w-]+)\/([\w-]+)\/blob\/([\w.-]+)\/(.+)$/;
+        /^https?:\/\/github\.com\/([\w-]+)\/([\w.-]+)\/blob\/([a-f0-9]+)\/(.+?)#(.+)$/;
+    const wholeFileRegex = /^https?:\/\/github\.com\/([\w-]+)\/([\w.-]+)\/blob\/([\w.-]+)\/(.+)$/;
     const multipleLineRegex = /^L\d+-L\d+$/;
 
     let orgName = '';


### PR DESCRIPTION
Resolves issue #822 related to GitHub Files integration by updating regexes for capturing URL to a file in a GitHub repository so that it also includes dots for repository names. 