### PR TITLE
Add missing publish integration staging script to Helpscout integration

### DIFF
--- a/.changeset/common-jobs-create.md
+++ b/.changeset/common-jobs-create.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-helpscout': patch
+---
+
+Add missing publish integration staging script for Helpscout integration

--- a/integrations/helpscout/package.json
+++ b/integrations/helpscout/package.json
@@ -2,15 +2,17 @@
     "name": "@gitbook/integration-helpscout",
     "private": true,
     "version": "1.5.0",
-    "scripts": {
-        "typecheck": "tsc --noEmit",
-        "publish": "gitbook publish ."
-    },
     "dependencies": {
         "@gitbook/runtime": "*"
     },
     "devDependencies": {
         "@gitbook/cli": "workspace:*",
         "@gitbook/tsconfig": "workspace:*"
+    },
+    "scripts": {
+        "typecheck": "tsc --noEmit",
+        "publish-integrations-staging": "gitbook publish .",
+        "check": "gitbook check",
+        "publish": "gitbook publish ."
     }
 }


### PR DESCRIPTION
The integration wasn't being published to staging. Also bumps the changeset for the integration to trigger a publish integration so that the `target` in prod reflects the target set in the manifest on the repo.