### PR TITLE
Fix missing channels in the configuration of the Slack integration

### DIFF
--- a/.changeset/fine-heads-join.md
+++ b/.changeset/fine-heads-join.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-slack': minor
+---
+
+Try to fix missing channels in Slack's configuration

--- a/bun.lock
+++ b/bun.lock
@@ -357,7 +357,7 @@
     },
     "integrations/mermaid": {
       "name": "@gitbook/integration-mermaid",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "dependencies": {
         "@gitbook/api": "*",
         "@gitbook/runtime": "*",
@@ -419,7 +419,7 @@
     },
     "integrations/posthog": {
       "name": "@gitbook/integration-posthog",
-      "version": "0.4.2",
+      "version": "1.0.0",
       "dependencies": {
         "@gitbook/api": "*",
         "@gitbook/runtime": "*",

--- a/integrations/slack/src/slack.ts
+++ b/integrations/slack/src/slack.ts
@@ -73,8 +73,10 @@ async function fetchChannelsByType(context: SlackRuntimeContext, types: string) 
 export async function getChannelsPaginated(context: SlackRuntimeContext) {
     // Make separate calls for public and private channels due to inconsistent Slack API filtering
     // when requesting multiple types together - some channels are missing from the response
-    const publicChannels = await fetchChannelsByType(context, 'public_channel');
-    const privateChannels = await fetchChannelsByType(context, 'private_channel');
+    const [publicChannels, privateChannels] = await Promise.all([
+        fetchChannelsByType(context, 'public_channel'),
+        fetchChannelsByType(context, 'private_channel'),
+    ]);
 
     // Combine results
     const allChannels = [...publicChannels, ...privateChannels];

--- a/integrations/slack/src/slack.ts
+++ b/integrations/slack/src/slack.ts
@@ -15,17 +15,15 @@ type SlackChannel = {
 };
 
 /**
- * Cloudflare workers have a maximum number of subrequests we can call (20 according to my
- * tests) https://developers.cloudflare.com/workers/platform/limits/#how-many-subrequests-can-i-make
- * TODO: Test with 50
+ * Cloudflare workers have a maximum number of subrequests we can call (50 on a free account)
+ * https://developers.cloudflare.com/workers/platform/limits/#how-many-subrequests-can-i-make
  */
-const maximumSubrequests = 20;
+const maximumSubrequests = 50;
 
 /**
- * Executes a Slack API request to fetch channels, handles pagination, then returns the merged
- * results.
+ * Helper function to fetch channels by type with pagination
  */
-export async function getChannelsPaginated(context: SlackRuntimeContext) {
+async function fetchChannelsByType(context: SlackRuntimeContext, types: string) {
     const channels: SlackChannel[] = [];
 
     let response = await slackAPI<{
@@ -39,7 +37,7 @@ export async function getChannelsPaginated(context: SlackRuntimeContext) {
         payload: {
             limit: 1000,
             exclude_archived: true,
-            types: 'public_channel,private_channel',
+            types,
         },
     });
     channels.push(...response?.channels);
@@ -57,7 +55,7 @@ export async function getChannelsPaginated(context: SlackRuntimeContext) {
             payload: {
                 limit: 1000,
                 exclude_archived: true,
-                types: 'public_channel,private_channel',
+                types,
                 cursor: response.response_metadata.next_cursor,
             },
         });
@@ -65,8 +63,24 @@ export async function getChannelsPaginated(context: SlackRuntimeContext) {
         numberOfCalls++;
     }
 
+    return channels;
+}
+
+/**
+ * Executes a Slack API request to fetch channels, handles pagination, then returns the merged
+ * results.
+ */
+export async function getChannelsPaginated(context: SlackRuntimeContext) {
+    // Make separate calls for public and private channels due to inconsistent Slack API filtering
+    // when requesting multiple types together - some channels are missing from the response
+    const publicChannels = await fetchChannelsByType(context, 'public_channel');
+    const privateChannels = await fetchChannelsByType(context, 'private_channel');
+
+    // Combine results
+    const allChannels = [...publicChannels, ...privateChannels];
+
     // Remove any duplicate as the pagination API could return duplicated channels
-    return channels.filter(
+    return allChannels.filter(
         (value, index, self) => index === self.findIndex((t) => t.id === value.id),
     );
 }


### PR DESCRIPTION
This PR aims to address an issue with unpredictable response for the Slack's `conversation.list` API endpoint which results in missing channels from the response.

Splitting the requests by filter appears to reveal some of the missing channels. 