### PR TITLE
Check if cookies have been accepted before tracking the page

### DIFF
--- a/.changeset/five-birds-post.md
+++ b/.changeset/five-birds-post.md
@@ -1,0 +1,11 @@
+---
+'@gitbook/integration-plausible': minor
+'@gitbook/integration-mixpanel': minor
+'@gitbook/integration-posthog': minor
+'@gitbook/integration-fathom': minor
+'@gitbook/integration-hotjar': minor
+'@gitbook/integration-heap': minor
+'@gitbook/integration-reo.dev': minor
+---
+
+Add check to see if cookies should be disabled or not

--- a/integrations/fathom/src/fathomScript.raw.js
+++ b/integrations/fathom/src/fathomScript.raw.js
@@ -5,9 +5,28 @@
     element.setAttribute('data-site', siteId);
     element.setAttribute('data-spa', 'auto');
     element.src = 'https://cdn.usefathom.com/script.js';
+    const GRANTED_COOKIE = '__gitbook_cookie_granted';
+
+    function getCookie(cname) {
+        const name = `${cname}=`;
+        const decodedCookie = decodeURIComponent(document.cookie);
+        const ca = decodedCookie.split(';');
+        for (let i = 0; i < ca.length; i++) {
+            let c = ca[i];
+            while (c.charAt(0) === ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) === 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return '';
+    }
 
     // Function to track external links
     function trackExternalLink(event) {
+        const disableCookies = getCookie(GRANTED_COOKIE) !== 'yes';
+
         var item = event.target.closest('a');
         if (!item) return;
 
@@ -21,6 +40,10 @@
     }
 
     element.onload = function () {
+        if (disableCookies) {
+            return;
+        }
+
         if (trackExternalLinks === true || trackExternalLinks === 'true') {
             // Use event delegation to capture clicks on all current and later loaded links
             doc.addEventListener('click', trackExternalLink);

--- a/integrations/heap/src/script.raw.js
+++ b/integrations/heap/src/script.raw.js
@@ -1,5 +1,29 @@
 (function (win, doc) {
     const trackingID = '<TO_REPLACE>';
+    const GRANTED_COOKIE = '__gitbook_cookie_granted';
+
+    function getCookie(cname) {
+        const name = `${cname}=`;
+        const decodedCookie = decodeURIComponent(document.cookie);
+        const ca = decodedCookie.split(';');
+        for (let i = 0; i < ca.length; i++) {
+            let c = ca[i];
+            while (c.charAt(0) === ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) === 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return '';
+    }
+
+    const disableCookies = getCookie(GRANTED_COOKIE) !== 'yes';
+
+    if (disableCookies) {
+        return;
+    }
+
     win.heap = win.heap || [];
     heap.load = function (e, t) {
         (win.heap.appid = e), (win.heap.config = t = t || {});

--- a/integrations/hotjar/src/script.raw.js
+++ b/integrations/hotjar/src/script.raw.js
@@ -1,5 +1,30 @@
 (function (h, o, t, j, a, r) {
     const trackingID = '<TO_REPLACE>';
+
+    const GRANTED_COOKIE = '__gitbook_cookie_granted';
+
+    function getCookie(cname) {
+        const name = `${cname}=`;
+        const decodedCookie = decodeURIComponent(document.cookie);
+        const ca = decodedCookie.split(';');
+        for (let i = 0; i < ca.length; i++) {
+            let c = ca[i];
+            while (c.charAt(0) === ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) === 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return '';
+    }
+
+    const disableCookies = getCookie(GRANTED_COOKIE) !== 'yes';
+
+    if (disableCookies) {
+        return;
+    }
+
     h.hj =
         h.hj ||
         function () {

--- a/integrations/mixpanel/src/script.raw.js
+++ b/integrations/mixpanel/src/script.raw.js
@@ -1,4 +1,28 @@
 (function (f, b) {
+    const GRANTED_COOKIE = '__gitbook_cookie_granted';
+
+    function getCookie(cname) {
+        const name = `${cname}=`;
+        const decodedCookie = decodeURIComponent(document.cookie);
+        const ca = decodedCookie.split(';');
+        for (let i = 0; i < ca.length; i++) {
+            let c = ca[i];
+            while (c.charAt(0) === ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) === 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return '';
+    }
+
+    const disableCookies = getCookie(GRANTED_COOKIE) !== 'yes';
+
+    if (disableCookies) {
+        return;
+    }
+
     if (!b.__SV) {
         var e, g, i, h;
         window.mixpanel = b;

--- a/integrations/plausible/src/plausibleScript.raw.js
+++ b/integrations/plausible/src/plausibleScript.raw.js
@@ -6,11 +6,35 @@
     const apiUrl = '<api>' || 'https://plausible.io/api/event';
     const domain = '<domain>';
 
+    const GRANTED_COOKIE = '__gitbook_cookie_granted';
+
+    function getCookie(cname) {
+        const name = `${cname}=`;
+        const decodedCookie = decodeURIComponent(document.cookie);
+        const ca = decodedCookie.split(';');
+        for (let i = 0; i < ca.length; i++) {
+            let c = ca[i];
+            while (c.charAt(0) === ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) === 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return '';
+    }
+
     function logIgnoredEvent(event) {
         console.warn('Ignoring Event: ' + event);
     }
 
     function trackEvent(eventName, options) {
+        const disableCookies = getCookie(GRANTED_COOKIE) !== 'yes';
+
+        if (disableCookies) {
+            return;
+        }
+
         if (
             /^localhost$|^127(\.[0-9]+){0,2}\.[0-9]+$|^\[::1?\]$/.test(currentUrl.hostname) ||
             'file:' === currentUrl.protocol

--- a/integrations/posthog/src/script.raw.js
+++ b/integrations/posthog/src/script.raw.js
@@ -1,7 +1,30 @@
 const projectApiKey = '<ph_project_api_key>';
 const instanceAddress = '<ph_instance_address>';
+const GRANTED_COOKIE = '__gitbook_cookie_granted';
+
+function getCookie(cname) {
+    const name = `${cname}=`;
+    const decodedCookie = decodeURIComponent(document.cookie);
+    const ca = decodedCookie.split(';');
+    for (let i = 0; i < ca.length; i++) {
+        let c = ca[i];
+        while (c.charAt(0) === ' ') {
+            c = c.substring(1);
+        }
+        if (c.indexOf(name) === 0) {
+            return c.substring(name.length, c.length);
+        }
+    }
+    return '';
+}
 
 !(function (t, e) {
+    const disableCookies = getCookie(GRANTED_COOKIE) !== 'yes';
+
+    if (disableCookies) {
+        return;
+    }
+
     var o, n, p, r;
     e.__SV ||
         ((window.posthog = e),

--- a/integrations/reo/src/script.raw.js
+++ b/integrations/reo/src/script.raw.js
@@ -1,6 +1,29 @@
 const trackingID = '<TO_REPLACE>';
+const GRANTED_COOKIE = '__gitbook_cookie_granted';
+
+function getCookie(cname) {
+    const name = `${cname}=`;
+    const decodedCookie = decodeURIComponent(document.cookie);
+    const ca = decodedCookie.split(';');
+    for (let i = 0; i < ca.length; i++) {
+        let c = ca[i];
+        while (c.charAt(0) === ' ') {
+            c = c.substring(1);
+        }
+        if (c.indexOf(name) === 0) {
+            return c.substring(name.length, c.length);
+        }
+    }
+    return '';
+}
 
 (function (r, e, o) {
+    const disableCookies = getCookie(GRANTED_COOKIE) !== 'yes';
+
+    if (disableCookies) {
+        return;
+    }
+
     var t, c, n;
     c = { clientID: trackingID };
     t = function () {


### PR DESCRIPTION
This PR should stop integrations from tracking analytics if the user has not accepted cookies or not - One thing I’m not sure, is if the page reloads after the cookie banner is accepted (meaning the cookie is set to yes, and then the integrations will fire?)

@sdirosa can you please have a look and make sure that I’ve implemented this correctly?