### PR TITLE
Release a new @gitbook/runtime version

### DIFF
--- a/.changeset/green-crews-exist.md
+++ b/.changeset/green-crews-exist.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/runtime': minor
+---
+
+New way to export fetch functions as esm

--- a/bun.lock
+++ b/bun.lock
@@ -381,7 +381,7 @@
     },
     "integrations/oidc": {
       "name": "@gitbook/integration-oidc",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "dependencies": {
         "@gitbook/api": "*",
         "@gitbook/runtime": "*",
@@ -493,7 +493,7 @@
     },
     "integrations/slack": {
       "name": "@gitbook/integration-slack",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "dependencies": {
         "@gitbook/api": "*",
         "@gitbook/runtime": "*",
@@ -614,7 +614,7 @@
     },
     "packages/api": {
       "name": "@gitbook/api",
-      "version": "0.128.0",
+      "version": "0.129.0",
       "dependencies": {
         "event-iterator": "^2.0.0",
         "eventsource-parser": "^3.0.0",


### PR DESCRIPTION
We forgot to run a changeset on `@gitbook/runtime` when we [changed the bundling strategy](https://github.com/GitbookIO/integrations/pull/836) from `iife` to `esm` which is causing issues with various integrations. 