### PR TITLE
Fix formspree fields

### DIFF
--- a/.changeset/loose-birds-shop.md
+++ b/.changeset/loose-birds-shop.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-formspree': patch
+---
+
+Update types in formspree integration to render email field correctly

--- a/integrations/formspree/gitbook-manifest.yaml
+++ b/integrations/formspree/gitbook-manifest.yaml
@@ -28,8 +28,8 @@ configurations:
         properties:
             formspree_id:
                 type: string
-                title: Formspree endpoint
-                description: The endpoint your formspree lives at.
+                title: Formspree ID
+                description: The ID of your formspree form. Copy this from the settings page of your formspree form.
             email:
                 type: boolean
                 title: Email

--- a/integrations/formspree/src/index.tsx
+++ b/integrations/formspree/src/index.tsx
@@ -64,7 +64,7 @@ const formspreeBlock = createComponent<
                                 label="Email"
                                 element={
                                     <textinput
-                                        inputType="email"
+                                        inputType="text"
                                         state="email"
                                         placeholder="Your email"
                                     />

--- a/integrations/formspree/src/index.tsx
+++ b/integrations/formspree/src/index.tsx
@@ -78,7 +78,13 @@ const formspreeBlock = createComponent<
                         <box grow={1}>
                             <input
                                 label="Name"
-                                element={<textinput state="name" placeholder="Your name" />}
+                                element={
+                                    <textinput
+                                        state="name"
+                                        placeholder="Your name"
+                                        inputType="text"
+                                    />
+                                }
                             />
                         </box>
                     ) : null}
@@ -93,6 +99,7 @@ const formspreeBlock = createComponent<
                                 element={
                                     <textinput
                                         state="message"
+                                        inputType="text"
                                         placeholder="Your message"
                                         multiline={true}
                                     />


### PR DESCRIPTION
The email field had an incorrect “email” `inputType` on it, causing it to not render correctly