### PR TITLE
Add cookie banner to tracking integraitons

### DIFF
--- a/.changeset/funny-pumas-change.md
+++ b/.changeset/funny-pumas-change.md
@@ -1,0 +1,11 @@
+---
+'@gitbook/integration-salesviewer': minor
+'@gitbook/integration-mixpanel': minor
+'@gitbook/integration-posthog': minor
+'@gitbook/integration-fathom': minor
+'@gitbook/integration-hotjar': minor
+'@gitbook/integration-heap': minor
+'@gitbook/integration-reo.dev': minor
+---
+
+Add cookie banner to tracking integrations

--- a/.changeset/rude-pigs-fix.md
+++ b/.changeset/rude-pigs-fix.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-plausible': minor
+---
+
+Move check for cookies into the tracking function

--- a/integrations/fathom/gitbook-manifest.yaml
+++ b/integrations/fathom/gitbook-manifest.yaml
@@ -14,6 +14,7 @@ script: ./src/index.ts
 # See https://developer.gitbook.com/integrations/configurations#scopes
 scopes:
     - site:script:inject
+    - site:script:cookies
 contentSecurityPolicy:
     script-src: |
         https://cdn.usefathom.com;

--- a/integrations/heap/gitbook-manifest.yaml
+++ b/integrations/heap/gitbook-manifest.yaml
@@ -13,6 +13,7 @@ script: ./src/index.ts
 # See https://developer.gitbook.com/integrations/configurations#scopes
 scopes:
     - site:script:inject
+    - site:script:cookies
 organization: gitbook
 contentSecurityPolicy:
     script-src: https://heapanalytics.com https://cdn.heapanalytics.com 'unsafe-inline';

--- a/integrations/hotjar/gitbook-manifest.yaml
+++ b/integrations/hotjar/gitbook-manifest.yaml
@@ -13,6 +13,7 @@ script: ./src/index.ts
 # See https://developer.gitbook.com/integrations/configurations#scopes
 scopes:
     - site:script:inject
+    - site:script:cookies
 organization: gitbook
 contentSecurityPolicy:
     script-src: static.hotjar.com script.hotjar.com;

--- a/integrations/mixpanel/gitbook-manifest.yaml
+++ b/integrations/mixpanel/gitbook-manifest.yaml
@@ -10,6 +10,7 @@ script: ./src/index.ts
 # See https://developer.gitbook.com/integrations/configurations#scopes
 scopes:
     - site:script:inject
+    - site:script:cookies
 organization: gitbook
 contentSecurityPolicy:
     script-src: cdn.mxpnl.com;

--- a/integrations/plausible/src/plausibleScript.raw.js
+++ b/integrations/plausible/src/plausibleScript.raw.js
@@ -29,10 +29,6 @@
     }
 
     function trackEvent(eventName, options) {
-        if (getCookie(GRANTED_COOKIE) !== 'yes') {
-            return;
-        }
-
         if (
             /^localhost$|^127(\.[0-9]+){0,2}\.[0-9]+$|^\[::1?\]$/.test(currentUrl.hostname) ||
             'file:' === currentUrl.protocol
@@ -84,6 +80,10 @@
 
     let currentPagePath;
     function trackPageView() {
+        if (getCookie(GRANTED_COOKIE) !== 'yes') {
+            return;
+        }
+
         if (currentPagePath !== currentUrl.pathname) {
             currentPagePath = currentUrl.pathname;
             trackEvent('pageview');

--- a/integrations/plausible/src/plausibleScript.raw.js
+++ b/integrations/plausible/src/plausibleScript.raw.js
@@ -29,6 +29,10 @@
     }
 
     function trackEvent(eventName, options) {
+        if (getCookie(GRANTED_COOKIE) !== 'yes') {
+            return;
+        }
+
         if (
             /^localhost$|^127(\.[0-9]+){0,2}\.[0-9]+$|^\[::1?\]$/.test(currentUrl.hostname) ||
             'file:' === currentUrl.protocol
@@ -80,10 +84,6 @@
 
     let currentPagePath;
     function trackPageView() {
-        if (getCookie(GRANTED_COOKIE) !== 'yes') {
-            return;
-        }
-
         if (currentPagePath !== currentUrl.pathname) {
             currentPagePath = currentUrl.pathname;
             trackEvent('pageview');

--- a/integrations/posthog/gitbook-manifest.yaml
+++ b/integrations/posthog/gitbook-manifest.yaml
@@ -13,6 +13,7 @@ script: ./src/index.ts
 # See https://developer.gitbook.com/integrations/configurations#scopes
 scopes:
     - site:script:inject
+    - site:script:cookies
 organization: gitbook
 contentSecurityPolicy:
     script-src: https://eu.posthog.com https://app.posthog.com;

--- a/integrations/reo/gitbook-manifest.yaml
+++ b/integrations/reo/gitbook-manifest.yaml
@@ -13,6 +13,7 @@ script: ./src/index.ts
 # See https://developer.gitbook.com/integrations/configurations#scopes
 scopes:
     - site:script:inject
+    - site:script:cookies
 organization: gitbook
 contentSecurityPolicy:
     script-src: static.reo.dev www.ipapi.co;

--- a/integrations/salesviewer/gitbook-manifest.yaml
+++ b/integrations/salesviewer/gitbook-manifest.yaml
@@ -3,43 +3,44 @@ title: SalesViewer
 icon: ./assets/icon.png
 description: Track and identify GitBook page visitors with Salesviewer analytics.
 previewImages:
-  - ./assets/salesviewer-preview.png
+    - ./assets/salesviewer-preview.png
 externalLinks:
-  - label: Documentation
-    url: https://www.salesviewer.com/en/help/
+    - label: Documentation
+      url: https://www.salesviewer.com/en/help/
 visibility: public
 organization: ebg2KXDsLAQnw4pxgpm6
 script: ./src/index.ts
 scopes:
-  - site:script:inject
+    - site:script:inject
+    - site:script:cookies
 contentSecurityPolicy:
-  script-src: |
-    https://slsnlytcs.com;
-  connect-src: |
-    slsnlytcs.com;
+    script-src: |
+        https://slsnlytcs.com;
+    connect-src: |
+        slsnlytcs.com;
 summary: |
-  # Overview
+    # Overview
 
-  SalesViewer® is a powerful analytics and visitor identification platform that helps you understand who visits your pages and track their behavior.
+    SalesViewer® is a powerful analytics and visitor identification platform that helps you understand who visits your pages and track their behavior.
 
-  # How it works
+    # How it works
 
-  The GitBook SalesViewer® integration allows you to track traffic in your published sites from your SalesViewer® dashboard.
+    The GitBook SalesViewer® integration allows you to track traffic in your published sites from your SalesViewer® dashboard.
 
-  Each of your connected GitBook sites will fetch the SalesViewer® tracking script and inject it in your public content, enabling visitor tracking and identification.
+    Each of your connected GitBook sites will fetch the SalesViewer® tracking script and inject it in your public content, enabling visitor tracking and identification.
 
-  # Configure
-  Install the integration on the GitBook site of your choice.
-  Locate the Account ID you want to use, which is available in SalesViewer® dashboard under "Profile > Project & Tracking code":
+    # Configure
+    Install the integration on the GitBook site of your choice.
+    Locate the Account ID you want to use, which is available in SalesViewer® dashboard under "Profile > Project & Tracking code":
 categories:
-  - analytics
+    - analytics
 configurations:
-  site:
-    properties:
-      tracking_id:
-        type: string
-        title: Tracking ID
-        description: Your SalesViewer® Account ID
-    required:
-      - tracking_id
+    site:
+        properties:
+            tracking_id:
+                type: string
+                title: Tracking ID
+                description: Your SalesViewer® Account ID
+        required:
+            - tracking_id
 target: site


### PR DESCRIPTION
Should fix https://github.com/orgs/GitbookIO/discussions/1055

As it stands, the cookie banners do not show because we were not showing them through the `site:script:cookies` scope. 

We recently added a change to the integrations to not fire analytics links if the cookie banner was not accepted, causing the bug in the community bug above. 

This should fix all affected integrations