### PR TITLE
Fix mermaid diagram not rendering in Safari

### DIFF
--- a/.changeset/fancy-meals-raise.md
+++ b/.changeset/fancy-meals-raise.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-mermaid': patch
+---
+
+Fix mermaid diagram not rendering in Safari

--- a/integrations/mermaid/src/index.tsx
+++ b/integrations/mermaid/src/index.tsx
@@ -138,6 +138,13 @@ export default createIntegration({
                             );
                         }
 
+                        function onLoaded(e) {
+                            console.log("mermaid: ready");
+                            sendAction({
+                                action: '@webframe.ready'
+                            });
+                        }
+
                         window.addEventListener("message", (event) => {
                             if (
                                 event.data &&
@@ -151,12 +158,12 @@ export default createIntegration({
                             }
                         });
 
-                        document.addEventListener("DOMContentLoaded", function(e) {
-                            console.log("mermaid: ready");
-                            sendAction({
-                                action: '@webframe.ready'
-                            });
-                        });
+
+                        if (document.readyState !== 'loading') {
+                            onLoaded();
+                        } else {
+                            document.addEventListener('DOMContentLoaded', onLoaded);
+                        }
                     </script>
                     <div id="content"></div>
                 </body>

--- a/integrations/segment/tests/events.test.ts
+++ b/integrations/segment/tests/events.test.ts
@@ -9,8 +9,6 @@ const fakeSpaceViewEvent: api.SiteViewEvent = {
     eventId: 'fake-event-id',
     type: 'site_view',
     siteId: 'fake-site-id',
-    spaceId: 'fake-space-id',
-    pageId: 'fake-page-id',
     installationId: 'fake-installation-id',
     visitor: {
         anonymousId: 'gitbookAnonymousId',
@@ -27,7 +25,7 @@ const fakeSpaceViewEvent: api.SiteViewEvent = {
 describe('events', () => {
     it('should generate the Segment Track Event with expected properties', () => {
         const expectedSegmentEvent = {
-            event: '[GitBook] space_view',
+            event: '[GitBook] site_view',
             anonymousId: 'gitbookAnonymousId',
             context: {
                 library: {
@@ -45,8 +43,6 @@ describe('events', () => {
             },
             properties: {
                 siteId: 'fake-site-id',
-                spaceId: 'fake-space-id',
-                pageId: 'fake-page-id',
             },
         };
         const actualSegmentEvent = generateSegmentTrackEvent(fakeSpaceViewEvent);


### PR DESCRIPTION
It looks like Safari doesn't fire the `DOMContentLoaded` event the same way other browser would (see [this](https://mikefallows.com/posts/avoiding-a-domcontentloaded-gotcha-with-readystate/) and [this](https://stackoverflow.com/questions/39993676/code-inside-domcontentloaded-event-not-working/39993724#39993724) and [this](https://developer.apple.com/forums/thread/651215))