### PR TITLE
Add configuration to fix tracking data in EU

### DIFF
--- a/.changeset/deep-grapes-feel.md
+++ b/.changeset/deep-grapes-feel.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-segment': minor
+---
+
+Add optional configuration to fix tracking data in EU

--- a/.changeset/eager-trams-shave.md
+++ b/.changeset/eager-trams-shave.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-segment': patch
+---
+
+Fix description length

--- a/.changeset/twelve-cooks-love.md
+++ b/.changeset/twelve-cooks-love.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-segment': patch
+---
+
+Update description

--- a/integrations/segment/gitbook-manifest.yaml
+++ b/integrations/segment/gitbook-manifest.yaml
@@ -31,7 +31,7 @@ summary: |
 
     In Segment, you can set up a source to receive the GitBook events. After adding an HTTP API source in Segment, you will see a Write Key. This key is used to identify the data source in GitBook.
 
-    If you are located in the EU, you may need to configure an optional parameter to track events successfully.
+    If you are [**located in the EU**](https://segment.com/docs/guides/eu-region/), you may need to configure an optional parameter to track events successfully.
 
     To install the Segment integration on a single space click on the Integrations button in sub-navigation. Alternatively, you can install it on multiple or all spaces by going into your organization settings. You will need the Segment Write Key to help you identify the data source.
 categories:
@@ -42,7 +42,7 @@ configurations:
             write_key:
                 type: string
                 title: Write Key
-                description: Key provided by Segment to identify the data source.
+                description: Key provided by Segment to identify the data source. If you are located in the EU, you will need to use an EU Write Key.
             eu_region:
                 type: boolean
                 title: EU Region

--- a/integrations/segment/gitbook-manifest.yaml
+++ b/integrations/segment/gitbook-manifest.yaml
@@ -31,7 +31,7 @@ summary: |
 
     In Segment, you can set up a source to receive the GitBook events. After adding an HTTP API source in Segment, you will see a Write Key. This key is used to identify the data source in GitBook.
 
-    If you are [**located in the EU**](https://segment.com/docs/guides/eu-region/), you may need to configure an optional parameter to track events successfully.
+    If you are [**located in the EU**](https://segment.com/docs/guides/eu-region/), you may need to configure an optional parameter to track events successfully. Additionally, you will need to [use an EU Write Key](https://segment.com/docs/guides/regional-segment/#custom-http-requests).
 
     To install the Segment integration on a single space click on the Integrations button in sub-navigation. Alternatively, you can install it on multiple or all spaces by going into your organization settings. You will need the Segment Write Key to help you identify the data source.
 categories:
@@ -42,7 +42,7 @@ configurations:
             write_key:
                 type: string
                 title: Write Key
-                description: Key provided by Segment to identify the data source. If you are located in the EU, you will need to use an EU Write Key.
+                description: Key provided by Segment to identify the data source. EU users must use an EU Write Key..
             eu_region:
                 type: boolean
                 title: EU Region

--- a/integrations/segment/gitbook-manifest.yaml
+++ b/integrations/segment/gitbook-manifest.yaml
@@ -31,6 +31,8 @@ summary: |
 
     In Segment, you can set up a source to receive the GitBook events. After adding an HTTP API source in Segment, you will see a Write Key. This key is used to identify the data source in GitBook.
 
+    If you are located in the EU, you may need to configure an optional parameter to track events successfully.
+
     To install the Segment integration on a single space click on the Integrations button in sub-navigation. Alternatively, you can install it on multiple or all spaces by going into your organization settings. You will need the Segment Write Key to help you identify the data source.
 categories:
     - analytics
@@ -41,6 +43,11 @@ configurations:
                 type: string
                 title: Write Key
                 description: Key provided by Segment to identify the data source.
+            eu_region:
+                type: boolean
+                title: EU Region
+                description: If you are located in the EU, this parameter is required to track events successfully.
+                default: false
         required:
             - write_key
 target: site

--- a/integrations/segment/src/index.ts
+++ b/integrations/segment/src/index.ts
@@ -7,6 +7,7 @@ type SegmentRuntimeContext = RuntimeContext<
         {},
         {
             write_key?: string;
+            eu_region?: boolean;
         }
     >
 >;
@@ -15,6 +16,12 @@ export default createIntegration<SegmentRuntimeContext>({
     events: {
         site_view: async (event, { environment }) => {
             const writeKey = environment.siteInstallation?.configuration.write_key;
+            const euRegion = environment.siteInstallation?.configuration.eu_region;
+
+            const segmentEndpoint = euRegion
+                ? 'https://events.eu1.segmentapis.com/v1/track'
+                : 'https://api.segment.io/v1/track';
+
             if (!writeKey) {
                 throw new Error(
                     `The Segment write key is missing from the Site (ID: ${event.siteId}) installation.`,
@@ -22,7 +29,7 @@ export default createIntegration<SegmentRuntimeContext>({
             }
 
             const trackEvent = generateSegmentTrackEvent(event);
-            await fetch('https://api.segment.io/v1/track', {
+            await fetch(segmentEndpoint, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',


### PR DESCRIPTION
Fixes #950 

We are using the wrong endpoint for customers located in the EU, meaning events are not successfully tracked. 

This PR adds a configuration to select if you are in the EU to use a different endpoint.

More info in the segment docs: https://segment.com/docs/connections/sources/catalog/libraries/server/http-api/