### PR TITLE
Webhook integration - 2nd pass

### DIFF
--- a/.changeset/smart-memes-lick.md
+++ b/.changeset/smart-memes-lick.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-webhook': minor
+---
+
+Added support for site events and secret regeneration.

--- a/docs/guides/webhook.md
+++ b/docs/guides/webhook.md
@@ -10,6 +10,29 @@ The GitBook Webhook Integration allows you to receive real-time notifications wh
 - **Configurable Events**: Choose which events to receive (site views, content updates, page feedback)
 
 ## Supported Events
+The webhook integration can be installed either in Spaces or in Sites. The list of events you can select depends on where the integration is installed.
+
+For spaces:
+- **Content updates** - When content in your space is modified
+
+For sites:
+- **Site views** - When users visit pages on your site
+- **Page feedback** - When users provide feedback on pages
+
+
+### Content Updated Events (`space_content_updated`)
+Triggered when content in a space is modified.
+
+**Payload Example:**
+```json
+{
+  "eventId": "evt_2345678901bcdefg",
+  "type": "space_content_updated",
+  "spaceId": "space_xyz789",
+  "installationId": "inst_def456",
+  "revisionId": "rev_abc123def456"
+}
+```
 
 ### Site View Events (`site_view`)
 Triggered when a user visits a page on your GitBook site.
@@ -31,20 +54,6 @@ Triggered when a user visits a page on your GitBook site.
   },
   "url": "https://docs.example.com/getting-started",
   "referrer": "https://www.google.com/search?q=example+docs"
-}
-```
-
-### Content Updated Events (`space_content_updated`)
-Triggered when content in a space is modified.
-
-**Payload Example:**
-```json
-{
-  "eventId": "evt_2345678901bcdefg",
-  "type": "space_content_updated",
-  "spaceId": "space_xyz789",
-  "installationId": "inst_def456",
-  "revisionId": "rev_abc123def456"
 }
 ```
 

--- a/integrations/webhook/README.md
+++ b/integrations/webhook/README.md
@@ -48,9 +48,12 @@ All webhook requests include an `X-GitBook-Signature` header with an HMAC-SHA256
 
 ## Supported Events
 
+For sites:
 - **Site views** - When users visit pages on your site
-- **Content updates** - When content in your space is modified
 - **Page feedback** - When users provide feedback on pages
+
+For spaces:
+- **Content updates** - When content in your space is modified
 
 ## Delivery and Retries
 

--- a/integrations/webhook/gitbook-manifest.yaml
+++ b/integrations/webhook/gitbook-manifest.yaml
@@ -31,6 +31,8 @@ summary: |
     After installing the integration, configure your webhook URL and select which events you want to receive. The integration will send HTTP POST requests to your endpoint with event data in JSON format.
 
 configurations:
+    account:
+        componentId: account-config
     space:
         componentId: config
     site:

--- a/integrations/webhook/gitbook-manifest.yaml
+++ b/integrations/webhook/gitbook-manifest.yaml
@@ -33,4 +33,8 @@ summary: |
 configurations:
     space:
         componentId: config
-target: space
+    site:
+        componentId: config
+    organization:
+        componentId: config
+target: all

--- a/integrations/webhook/gitbook-manifest.yaml
+++ b/integrations/webhook/gitbook-manifest.yaml
@@ -35,6 +35,4 @@ configurations:
         componentId: config
     site:
         componentId: config
-    organization:
-        componentId: config
 target: all

--- a/integrations/webhook/src/common.ts
+++ b/integrations/webhook/src/common.ts
@@ -23,12 +23,16 @@ export const MAX_RETRIES = 3;
 export const BASE_DELAY = 1000;
 export const REQUEST_TIMEOUT = 10000;
 
-export type WebhookConfiguration = {
+export type WebhookConfiguration = Record<EventType, boolean>;
+
+export type WebhookAccountConfiguration = {
     webhookUrl: string;
     secret: string;
-} & Record<EventType, boolean>;
+};
 
-export type WebhookRuntimeContext = RuntimeContext<RuntimeEnvironment<{}, WebhookConfiguration>>;
+export type WebhookRuntimeContext = RuntimeContext<
+    RuntimeEnvironment<WebhookAccountConfiguration, WebhookConfiguration>
+>;
 
 /**
  * Shared webhook delivery logic with built-in retry mechanism

--- a/integrations/webhook/src/config.tsx
+++ b/integrations/webhook/src/config.tsx
@@ -75,7 +75,6 @@ export const accountConfigComponent = createComponent<
             <configuration>
                 <input
                     label="Webhook URL"
-                    hint={<text>The URL where the events will be sent.</text>}
                     element={
                         <textinput
                             state="webhookUrl"
@@ -88,10 +87,7 @@ export const accountConfigComponent = createComponent<
 
                 <markdown content="### Secret" />
                 <text>
-                    Use this secret to verify the GitBook webhook signatures (SHA-256 HMAC).
-                </text>
-                <text>
-                    See our{' '}
+                    Use this secret to verify the GitBook webhook signatures (SHA-256 HMAC). See our{' '}
                     <link
                         target={{
                             url: 'https://gitbook.com/docs/integrations/webhook#signature-verification-example',

--- a/integrations/webhook/src/config.tsx
+++ b/integrations/webhook/src/config.tsx
@@ -124,7 +124,7 @@ export const accountConfigComponent = createComponent<
                     element={
                         <button
                             style="primary"
-                            label="Save changes"
+                            label="Save organization changes"
                             tooltip="Save webhook URL and secret"
                             onPress={{
                                 action: 'save.config',
@@ -288,7 +288,7 @@ export const configComponent = createComponent<
                     element={
                         <button
                             style="primary"
-                            label={`Save changes`}
+                            label={`Save ${installationLevel === 'space' ? 'space' : 'site'} changes`}
                             tooltip={`Save event preferences for this ${installationLevel}`}
                             onPress={{
                                 action: 'save.config',

--- a/integrations/webhook/src/config.tsx
+++ b/integrations/webhook/src/config.tsx
@@ -124,7 +124,7 @@ export const accountConfigComponent = createComponent<
                     element={
                         <button
                             style="primary"
-                            label="Save Account Configuration"
+                            label="Save changes"
                             tooltip="Save webhook URL and secret"
                             onPress={{
                                 action: 'save.config',
@@ -288,7 +288,7 @@ export const configComponent = createComponent<
                     element={
                         <button
                             style="primary"
-                            label={`Save ${installationLevel === 'space' ? 'Space' : 'Site'} Configuration`}
+                            label={`Save changes`}
                             tooltip={`Save event preferences for this ${installationLevel}`}
                             onPress={{
                                 action: 'save.config',

--- a/integrations/webhook/src/config.tsx
+++ b/integrations/webhook/src/config.tsx
@@ -261,16 +261,6 @@ export const configComponent = createComponent<
             // Site level: site views and page feedback
             availableEvents = [EventType.SITE_VIEW, EventType.PAGE_FEEDBACK];
             installationLevel = 'site';
-        } else if (environment.installation) {
-            // Organization level: no configuration allowed
-            return (
-                <configuration>
-                    <text>
-                        This integration cannot be configured at the organization level. Please
-                        install it on individual spaces or sites to configure webhook events.
-                    </text>
-                </configuration>
-            );
         } else {
             return (
                 <configuration>

--- a/integrations/webhook/src/index.ts
+++ b/integrations/webhook/src/index.ts
@@ -1,7 +1,7 @@
 import { createIntegration, Logger } from '@gitbook/runtime';
 import { Event } from '@gitbook/api';
 
-import { configComponent } from './config';
+import { configComponent, accountConfigComponent } from './config';
 import {
     WebhookRuntimeContext,
     EventType,
@@ -18,22 +18,24 @@ const logger = Logger('webhook');
 const handleWebhookEvent = async (event: Event, context: WebhookRuntimeContext) => {
     const { environment } = context;
 
-    // Get configuration from whichever installation type is available
-    const installation = environment.spaceInstallation || environment.siteInstallation;
-
-    // For organization-level installations, check the installation configuration
-    let config: any;
-    if (installation) {
-        config = installation.configuration;
-    } else if (environment.installation) {
-        config = environment.installation.configuration;
-    } else {
-        logger.debug('No installation found');
+    // Get account-level configuration (webhookUrl and secret)
+    const accountConfig = environment.installation?.configuration;
+    if (!accountConfig?.webhookUrl || !accountConfig?.secret) {
+        logger.debug('Account-level webhook configuration not found');
         return;
     }
 
+    // Get event preferences from space/site installation
+    const installation = environment.spaceInstallation || environment.siteInstallation;
+    if (!installation) {
+        logger.debug('No space or site installation found');
+        return;
+    }
+
+    const eventConfig = installation.configuration;
+
     // Check if this event type is supported and enabled
-    if (!EVENT_TYPES.includes(event.type as EventType) || !config[event.type as EventType]) {
+    if (!EVENT_TYPES.includes(event.type as EventType) || !eventConfig[event.type as EventType]) {
         logger.debug(`Event ${event.type} is not enabled`);
         return;
     }
@@ -46,12 +48,19 @@ const handleWebhookEvent = async (event: Event, context: WebhookRuntimeContext) 
     // Generate HMAC signature for webhook verification
     const signature = await generateHmacSignature({
         payload: jsonPayload,
-        secret: config.secret,
+        secret: accountConfig.secret,
         timestamp,
     });
 
     context.waitUntil(
-        deliverWebhook(context, event, config.webhookUrl, config.secret, timestamp, signature),
+        deliverWebhook(
+            context,
+            event,
+            accountConfig.webhookUrl,
+            accountConfig.secret,
+            timestamp,
+            signature,
+        ),
     );
 };
 
@@ -62,7 +71,7 @@ const events: Record<EventType, typeof handleWebhookEvent> = {
 };
 
 export default createIntegration<WebhookRuntimeContext>({
-    components: [configComponent],
+    components: [accountConfigComponent, configComponent],
     events,
     fetch: async (request, context) => {
         return new Response('Not found', { status: 404 });

--- a/integrations/webhook/src/index.ts
+++ b/integrations/webhook/src/index.ts
@@ -17,14 +17,20 @@ const logger = Logger('webhook');
  */
 const handleWebhookEvent = async (event: Event, context: WebhookRuntimeContext) => {
     const { environment } = context;
-    const spaceInstallation = environment.spaceInstallation;
 
-    if (!spaceInstallation) {
-        logger.debug('No space installation found');
+    // Get configuration from whichever installation type is available
+    const installation = environment.spaceInstallation || environment.siteInstallation;
+
+    // For organization-level installations, check the installation configuration
+    let config: any;
+    if (installation) {
+        config = installation.configuration;
+    } else if (environment.installation) {
+        config = environment.installation.configuration;
+    } else {
+        logger.debug('No installation found');
         return;
     }
-
-    const config = spaceInstallation.configuration;
 
     // Check if this event type is supported and enabled
     if (!EVENT_TYPES.includes(event.type as EventType) || !config[event.type as EventType]) {


### PR DESCRIPTION
Second iteration on the webhook integration.

Adds:
- Dynamic configuration panels for the integration, to show only events relevant to an installation
- Store secret and webhook at org level, so they get inherited in all installations
- Fix site events
- Improve docs to clarify site vs spaces events

### Site config
<img width="929" height="896" alt="CleanShot 2025-09-19 at 14 45 09" src="https://github.com/user-attachments/assets/5c218d4b-c44d-491b-8ede-c7dc9be6554a" />

### Space config
<img width="929" height="896" alt="CleanShot 2025-09-19 at 14 46 26" src="https://github.com/user-attachments/assets/1cc9f4c3-141e-4570-9fda-b4c9da394b23" />
