### PR TITLE
Fix webhook integration docs links

### DIFF
--- a/integrations/webhook/gitbook-manifest.yaml
+++ b/integrations/webhook/gitbook-manifest.yaml
@@ -5,7 +5,7 @@ organization: gitbook
 description: Send GitBook events to your webhook endpoints.
 externalLinks:
     - label: Documentation
-      url: https://gitbook.com/docs/integrations/webhook
+      url: https://gitbook.com/docs/developers/guides/webhook
 categories:
     - other
 visibility: public

--- a/integrations/webhook/src/config.tsx
+++ b/integrations/webhook/src/config.tsx
@@ -90,7 +90,7 @@ export const accountConfigComponent = createComponent<
                     Use this secret to verify the GitBook webhook signatures (SHA-256 HMAC). See our{' '}
                     <link
                         target={{
-                            url: 'https://gitbook.com/docs/integrations/webhook#signature-verification-example',
+                            url: 'https://gitbook.com/docs/developers/guides/webhook#signature-verification-example',
                         }}
                     >
                         documentation

--- a/integrations/webhook/src/config.tsx
+++ b/integrations/webhook/src/config.tsx
@@ -70,7 +70,7 @@ export const accountConfigComponent = createComponent<
             }
         }
     },
-    render: async (element) => {
+    render: async (element, context) => {
         return (
             <configuration>
                 <input
@@ -90,7 +90,7 @@ export const accountConfigComponent = createComponent<
                     Use this secret to verify the GitBook webhook signatures (SHA-256 HMAC). See our{' '}
                     <link
                         target={{
-                            url: 'https://gitbook.com/docs/developers/guides/webhook#signature-verification-example',
+                            url: `${context.environment.integration.externalLinks[0]?.url}#signature-verification-example`,
                         }}
                     >
                         documentation


### PR DESCRIPTION
They were moved, but the manifest and config were still pointing to the old url. 
Took the opportunity to use the link from the manifest in the config as well.