### PR TITLE
Fix initial ingestion failing due to Intercom API timeouts

### DIFF
--- a/integrations/intercom-conversations/src/conversations.ts
+++ b/integrations/intercom-conversations/src/conversations.ts
@@ -48,8 +48,6 @@ export async function ingestLastClosedIntercomConversations(context: IntercomRun
         },
     );
 
-    logger.info(`First page of conversation fetched.`);
-
     const tasks: Array<IntercomIntegrationTask> = [];
     while (pageIndex < maxPages) {
         pageIndex += 1;
@@ -69,7 +67,6 @@ export async function ingestLastClosedIntercomConversations(context: IntercomRun
             break;
         }
 
-        logger.info(`Fetching next page ${pageIndex + 1}.`);
         page = await page.getNextPage();
     }
 


### PR DESCRIPTION
**Note:** ⚠️ This is only a mitigation for now but I believe we should be revisiting the criteria we use for initially retrieving (at install time) the closed conversations from Intercom. Maybe by adding a filter to search for conversations that were closed in the last 30 days or similar to help optimize the search query instead of the broader criteria we use right now.
Alternatively we could allow customers in the integration configuration screen specify a query that could help filters the ones they are really interested in using for ingestion.

This PR addresses Intercom API timeouts occurring during the initial fetch of closed conversations.

Currently, we request 100 items per page, which causes each search call to take around 18 seconds. After fetching about 5–6 pages, the API begins timing out:

<img width="1224" height="278" alt="Screenshot 2025-11-06 at 16 50 17" src="https://github.com/user-attachments/assets/f7246795-2e58-4150-a762-aea3564e5706" />

To mitigate these timeouts, this PR reduces the number of conversations fetched per page, bringing the latency per search call down to 6–8 seconds:

<img width="1224" height="563" alt="Screenshot 2025-11-06 at 16 50 27" src="https://github.com/user-attachments/assets/de7c4736-7c77-4f6a-8be8-b55624f4c5d4" />

**Note:** Since we previously fixed worker execution timeouts in [#1025](https://github.com/GitbookIO/integrations/pull/1025), by offloading parts of the workload (e.g. fetching conversation details, processing ~700 conversations, and ingestion) into batched task executions, we should now be in a good position regarding Intercom API rate limits.