### PR TITLE
Fix git sync export showing no commit message for computed revisions

### DIFF
--- a/.changeset/khaki-trees-enjoy.md
+++ b/.changeset/khaki-trees-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@gitbook/integration-github': patch
+'@gitbook/integration-gitlab': patch
+---
+
+Fix git sync export showing no commit message for computed revisions

--- a/integrations/github/src/sync.ts
+++ b/integrations/github/src/sync.ts
@@ -141,7 +141,10 @@ export async function triggerExport(
 
     logger.info(`Initiating an export from space ${spaceId} to GitHub`);
 
-    const { data: revision } = await api.spaces.getCurrentRevision(spaceId);
+    // We only need the source revision here so mergedFrom is preserved for the export commit
+    // message. Computed revision details are not needed here because the runner git sync
+    // computes the revision anyway.
+    const { data: revision } = await api.spaces.getCurrentRevision(spaceId, { computed: false });
 
     const auth = await getRepositoryAuth(context, config, false);
     const repoTreeURL = getGitTreeURL(config);

--- a/integrations/gitlab/src/sync.ts
+++ b/integrations/gitlab/src/sync.ts
@@ -134,7 +134,10 @@ export async function triggerExport(
 
     logger.info(`Initiating an export from space ${spaceId} to GitLab`);
 
-    const { data: revision } = await api.spaces.getCurrentRevision(spaceId);
+    // We only need the source revision here so mergedFrom is preserved for the export commit
+    // message. Computed revision details are not needed here because the runner git sync
+    // computes the revision anyway.
+    const { data: revision } = await api.spaces.getCurrentRevision(spaceId, { computed: false });
 
     const auth = await getRepositoryAuth(config);
     const repoTreeURL = getGitTreeURL(config);


### PR DESCRIPTION
This PR aims to fix Git sync exports showing GitBook: No commit message when the revision is a `computed` revision.

More [context](https://gitbook.slack.com/archives/C01NXGWJELS/p1776336411577339?thread_ts=1776330439.987039&cid=C01NXGWJELS)