### PR TITLE
Fix git sync export showing no commit message for computed revisions

### DIFF
--- a/.changeset/mighty-insects-peel.md
+++ b/.changeset/mighty-insects-peel.md
@@ -1,0 +1,7 @@
+---
+'@gitbook/api': minor
+'@gitbook/integration-github': patch
+'@gitbook/integration-gitlab': patch
+---
+
+Fix git sync export showing no commit message for computed revisions

--- a/integrations/github/src/sync.ts
+++ b/integrations/github/src/sync.ts
@@ -213,7 +213,8 @@ export async function updateCommitWithPreviewLinks(
  * Get the commit message for the export of a revision.
  */
 function getCommitMessageForRevision(config: GitHubSpaceConfiguration, revision: Revision): string {
-    const changeRequest = revision.type === 'merge' ? revision.mergedFrom : null;
+    const changeRequest =
+        revision.type === 'merge' || revision.type === 'computed' ? revision.mergedFrom : null;
 
     if (!changeRequest) {
         return `GitBook: No commit message`;

--- a/integrations/gitlab/src/sync.ts
+++ b/integrations/gitlab/src/sync.ts
@@ -206,7 +206,8 @@ export async function updateCommitWithPreviewLinks(
  * Get the commit message for the export of a revision.
  */
 function getCommitMessageForRevision(config: GitLabSpaceConfiguration, revision: Revision): string {
-    const changeRequest = revision.type === 'merge' ? revision.mergedFrom : null;
+    const changeRequest =
+        revision.type === 'merge' || revision.type === 'computed' ? revision.mergedFrom : null;
 
     if (!changeRequest) {
         return `GitBook: No commit message`;


### PR DESCRIPTION
Following https://github.com/GitbookIO/gitbook-x/pull/22662 we need to update the gitsync integrations accordingly so they can pull down the mergedFrom details for computed revisions too.