### PR TITLE
Include update authors in Slack space update notifications

### DIFF
--- a/.changeset/silver-pugs-report.md
+++ b/.changeset/silver-pugs-report.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-slack': minor
+---
+
+Include the authors of the content update in space update notifications

--- a/integrations/slack/src/index.ts
+++ b/integrations/slack/src/index.ts
@@ -42,6 +42,8 @@ const handleSpaceContentUpdated: EventCallback<
         return;
     }
 
+    const authors = (event.updatedBy ?? []).map((user) => user.displayName).filter(Boolean);
+
     const createdPages: ChangedRevisionPage[] = [];
     const editedPages: ChangedRevisionPage[] = [];
     const deletedPages: ChangedRevisionPage[] = [];
@@ -227,7 +229,7 @@ const handleSpaceContentUpdated: EventCallback<
         elements: [
             {
                 type: 'mrkdwn',
-                text: `📊 *${totalChanges} total changes* • Updated just now`,
+                text: `📊 *${totalChanges} total changes* • Updated just now${authors.length > 0 ? ` by ${authors.join(', ')}` : ''}`,
             },
         ],
     });


### PR DESCRIPTION
## Summary

When a `space_content_updated` event is received, the Slack notification now shows **who made the changes**, using the `updatedBy` field (a list of users) from the event payload.

The notification footer goes from:

> 📊 **3 total changes** • Updated just now

to:

> 📊 **3 total changes** • Updated just now by Jane Doe, John Smith

## Implementation notes

- The author list comes directly from the event payload (`event.updatedBy`), so no extra API call is needed.
- `event.updatedBy ?? []` guards against older events emitted before the field existed, and users without a display name are filtered out. When no author is available, the footer falls back to the previous text.
- Requires `@gitbook/api` types that include `updatedBy` on `SpaceContentUpdatedEvent` (already present in the workspace-generated client).

## Changeset

Minor bump of `@gitbook/integration-slack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)