### PR TITLE
Update CSP for plausible integration

### DIFF
--- a/.changeset/fine-wings-double.md
+++ b/.changeset/fine-wings-double.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-plausible': minor
+---
+
+Fix CSP for plausible integration

--- a/integrations/plausible/gitbook-manifest.yaml
+++ b/integrations/plausible/gitbook-manifest.yaml
@@ -15,11 +15,8 @@ script: ./src/index.ts
 scopes:
     - site:script:inject
 contentSecurityPolicy:
-    script-src: |
-        https://plausible.io;
-    connect-src: |
-        plausible.io
-        *;
+    script-src: https://plausible.io
+    connect-src: https://plausible.io *
 summary: |
     # Overview
 


### PR DESCRIPTION
Fixes an issue where Plausible isn’t picking up on the set CSP required for the integration to work