### PR TITLE
Update Plausible integration to use Script instead of API

### DIFF
--- a/.changeset/sweet-grapes-end.md
+++ b/.changeset/sweet-grapes-end.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-plausible': major
+---
+
+Update Plausible integration to use script instead of API

--- a/integrations/plausible/gitbook-manifest.yaml
+++ b/integrations/plausible/gitbook-manifest.yaml
@@ -37,11 +37,11 @@ configurations:
             scriptKey:
                 type: string
                 title: Script key
-                description: The script key from your Plausible snippet (the "pa-XXXX" filename in the script src URL, e.g. "pa-W5AL4qmg42q0QIrC2P57z").
+                description: The "pa-XXXX" key from your Plausible snippet URL.
             selfHostedUrl:
                 type: string
                 title: Self-hosted URL
-                description: When self-hosting Plausible, set the base URL of your instance (e.g. "https://plausible.example.com"). Leave empty when using plausible.io.
+                description: Base URL of your self-hosted Plausible instance. Leave empty for plausible.io.
         required:
             - scriptKey
 target: site

--- a/integrations/plausible/gitbook-manifest.yaml
+++ b/integrations/plausible/gitbook-manifest.yaml
@@ -15,7 +15,7 @@ script: ./src/index.ts
 scopes:
     - site:script:inject
 contentSecurityPolicy:
-    script-src: https://plausible.io
+    script-src: https://plausible.io *
     connect-src: https://plausible.io *
 summary: |
     # Overview
@@ -34,14 +34,14 @@ categories:
 configurations:
     site:
         properties:
-            domain:
+            scriptKey:
                 type: string
-                title: Domain
-                description: The domain URL you configured for this Plausible website.
-            api:
+                title: Script key
+                description: The script key from your Plausible snippet (the "pa-XXXX" filename in the script src URL, e.g. "pa-W5AL4qmg42q0QIrC2P57z").
+            selfHostedUrl:
                 type: string
-                title: Self-hosted API
-                description: When self-hosting, configure the url of the instance API (empty when using plausible.io).
+                title: Self-hosted URL
+                description: When self-hosting Plausible, set the base URL of your instance (e.g. "https://plausible.example.com"). Leave empty when using plausible.io.
         required:
-            - domain
+            - scriptKey
 target: site

--- a/integrations/plausible/src/index.ts
+++ b/integrations/plausible/src/index.ts
@@ -11,8 +11,8 @@ type PlausibleRuntimeContext = RuntimeContext<
     RuntimeEnvironment<
         {},
         {
-            domain?: string;
-            api?: string;
+            scriptKey?: string;
+            selfHostedUrl?: string;
         }
     >
 >;
@@ -21,13 +21,16 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     event,
     { environment }: PlausibleRuntimeContext,
 ) => {
-    const domain = environment.siteInstallation?.configuration?.domain;
-    const api = environment.siteInstallation?.configuration?.api || '';
-    if (!domain) {
+    const scriptKey = environment.siteInstallation?.configuration?.scriptKey;
+    const selfHostedUrl = environment.siteInstallation?.configuration?.selfHostedUrl || '';
+    if (!scriptKey) {
         return;
     }
 
-    return new Response((script as string).replace('<domain>', domain).replace('<api>', api), {
+    const baseUrl = selfHostedUrl || 'https://plausible.io';
+    const scriptSrc = `${baseUrl}/js/${scriptKey}.js`;
+
+    return new Response((script as string).replace('<scriptSrc>', scriptSrc), {
         headers: {
             'Content-Type': 'application/javascript',
             'Cache-Control': 'max-age=604800',

--- a/integrations/plausible/src/plausibleScript.raw.js
+++ b/integrations/plausible/src/plausibleScript.raw.js
@@ -1,91 +1,18 @@
-// Taken from plausible.io/js/script.js
 (function () {
-    const currentUrl = window.location;
-    const document = window.document;
-
-    const apiUrl = '<api>' || 'https://plausible.io/api/event';
-    const domain = '<domain>';
-
-    function logIgnoredEvent(event) {
-        console.warn('Ignoring Event: ' + event);
-    }
-
-    function trackEvent(eventName, options) {
-        if (
-            /^localhost$|^127(\.[0-9]+){0,2}\.[0-9]+$|^\[::1?\]$/.test(currentUrl.hostname) ||
-            'file:' === currentUrl.protocol
-        ) {
-            return logIgnoredEvent('localhost');
-        }
-
-        if (
-            !(window._phantom || window.__nightmare || window.navigator.webdriver || window.Cypress)
-        ) {
-            try {
-                if (window.localStorage.plausible_ignore === 'true') {
-                    return logIgnoredEvent('localStorage flag');
-                }
-            } catch (error) {
-                // do nothing
-            }
-
-            const eventData = {};
-            eventData.name = eventName;
-            eventData.url = currentUrl.href;
-            eventData.domain = domain;
-            eventData.referrer = document.referrer || null;
-            eventData.width = window.innerWidth;
-            if (options && options.meta) {
-                eventData.meta = JSON.stringify(options.meta);
-            }
-            if (options && options.props) {
-                eventData.props = options.props;
-            }
-
-            const xhr = new XMLHttpRequest();
-            xhr.open('POST', apiUrl, true);
-            xhr.setRequestHeader('Content-Type', 'text/plain');
-            xhr.send(JSON.stringify(eventData));
-            xhr.onreadystatechange = function () {
-                if (xhr.readyState === 4 && options && options.callback) {
-                    options.callback();
-                }
-            };
-        }
-    }
-
-    const eventQueue = (window.plausible && window.plausible.q) || [];
-    window.plausible = trackEvent;
-    for (let i = 0; i < eventQueue.length; i++) {
-        trackEvent.apply(this, eventQueue[i]);
-    }
-
-    let currentPagePath;
-    function trackPageView() {
-        if (currentPagePath !== currentUrl.pathname) {
-            currentPagePath = currentUrl.pathname;
-            trackEvent('pageview');
-        }
-    }
-
-    let originalPushState;
-    const history = window.history;
-    if (history.pushState) {
-        originalPushState = history.pushState;
-        history.pushState = function () {
-            originalPushState.apply(this, arguments);
-            trackPageView();
+    window.plausible =
+        window.plausible ||
+        function () {
+            (plausible.q = plausible.q || []).push(arguments);
         };
-        window.addEventListener('popstate', trackPageView);
-    }
+    plausible.init =
+        plausible.init ||
+        function (i) {
+            plausible.o = i || {};
+        };
+    plausible.init();
 
-    if (document.visibilityState === 'prerender') {
-        document.addEventListener('visibilitychange', function () {
-            if (!currentPagePath && document.visibilityState === 'visible') {
-                trackPageView();
-            }
-        });
-    } else {
-        trackPageView();
-    }
+    var s = document.createElement('script');
+    s.async = true;
+    s.src = '<scriptSrc>';
+    document.head.appendChild(s);
 })();


### PR DESCRIPTION
Migrates the Plausible integration from a custom API-based tracking implementation to Plausible's official script tag approach.

Previously, the integration served a hand-rolled tracking script that posted events directly to the Plausible Events API. This required users to configure their tracked domain separately and bundled a large JS implementation that could drift from Plausible's own script.

The new approach injects Plausible's hosted script (e.g. https://plausible.io/js/pa-XXXX.js) dynamically, keeping tracking behaviour fully in sync with Plausible's own releases.

Configuration changes:
- domain → scriptKey: the pa-XXXX key from the user's Plausible snippet URL (required)
- api → selfHostedUrl: base URL for self-hosted Plausible instances (optional, unchanged in purpose)