### PR TITLE
Only fire Segment events when tracking consent is granted

### DIFF
--- a/.changeset/segment-consent.md
+++ b/.changeset/segment-consent.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-segment': minor
+---
+
+Only send Segment events when the visitor has granted cookie tracking consent

--- a/integrations/segment/gitbook-manifest.yaml
+++ b/integrations/segment/gitbook-manifest.yaml
@@ -21,6 +21,7 @@ summary: |
 
     Automatic page view events on your public documentation:
     Each of your connected GitBook sites will send a `[GitBook] site_view` event to the associated Segment source.
+    Events are only sent once the visitor has accepted tracking cookies, so tracking respects your site's cookie consent.
 
     Track your users' actions across all your company's websites:
     - Each `[GitBook] site_view` includes the `anonymousId` property.

--- a/integrations/segment/src/events.ts
+++ b/integrations/segment/src/events.ts
@@ -2,6 +2,17 @@ import * as api from '@gitbook/api';
 
 import { version } from '../package.json';
 
+// GitBook's cookie banner (or a consent manager like OneTrust) sets this cookie to
+// `yes` once the visitor accepts tracking cookies.
+const GRANTED_COOKIE = '__gitbook_cookie_granted';
+
+/**
+ * Whether the visitor has granted tracking-cookie consent.
+ */
+export function hasTrackingConsent(event: api.SiteViewEvent): boolean {
+    return event.visitor.cookies[GRANTED_COOKIE] === 'yes';
+}
+
 /**
  * Generate the event to track in Segment for an actual GitBook event.
  */

--- a/integrations/segment/src/index.ts
+++ b/integrations/segment/src/index.ts
@@ -1,6 +1,6 @@
 import { createIntegration, RuntimeContext, RuntimeEnvironment } from '@gitbook/runtime';
 
-import { generateSegmentTrackEvent } from './events';
+import { generateSegmentTrackEvent, hasTrackingConsent } from './events';
 
 type SegmentRuntimeContext = RuntimeContext<
     RuntimeEnvironment<
@@ -15,6 +15,10 @@ type SegmentRuntimeContext = RuntimeContext<
 export default createIntegration<SegmentRuntimeContext>({
     events: {
         site_view: async (event, { environment }) => {
+            if (!hasTrackingConsent(event)) {
+                return;
+            }
+
             const writeKey = environment.siteInstallation?.configuration.write_key;
             const euRegion = environment.siteInstallation?.configuration.eu_region;
 

--- a/integrations/segment/tests/events.test.ts
+++ b/integrations/segment/tests/events.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'bun:test';
 import type * as api from '@gitbook/api';
 
 import packageJson from '../package.json';
-import { generateSegmentTrackEvent } from '../src/events';
+import { generateSegmentTrackEvent, hasTrackingConsent } from '../src/events';
 
 const fakeSpaceViewEvent: api.SiteViewEvent = {
     eventId: 'fake-event-id',
@@ -68,5 +68,26 @@ describe('events', () => {
     it('should fallback to sending GitBook anonymousId value as anonymousId when ajs_anonymous_id is not present', () => {
         const segmentEvent = generateSegmentTrackEvent(fakeSpaceViewEvent);
         expect(segmentEvent.anonymousId).toEqual('gitbookAnonymousId');
+    });
+});
+
+describe('hasTrackingConsent', () => {
+    function withCookies(cookies: Record<string, string>): api.SiteViewEvent {
+        return {
+            ...fakeSpaceViewEvent,
+            visitor: { ...fakeSpaceViewEvent.visitor, cookies },
+        };
+    }
+
+    it('should return true when the consent cookie is granted', () => {
+        expect(hasTrackingConsent(withCookies({ __gitbook_cookie_granted: 'yes' }))).toBe(true);
+    });
+
+    it('should return false when the consent cookie is absent', () => {
+        expect(hasTrackingConsent(fakeSpaceViewEvent)).toBe(false);
+    });
+
+    it('should return false when the consent cookie is not granted', () => {
+        expect(hasTrackingConsent(withCookies({ __gitbook_cookie_granted: 'no' }))).toBe(false);
     });
 });


### PR DESCRIPTION
Gate the server-side site_view handler on the `__gitbook_cookie_granted` cookie so Segment respects the visitor's cookie consent (built-in banner and OneTrust). Previously events were sent on every page view regardless of consent.