### PR TITLE
Document webframe navigate action

### DIFF
--- a/docs/integrations/configurations.md
+++ b/docs/integrations/configurations.md
@@ -98,7 +98,6 @@ The scopes your integration has permissions for.
     - site:script:inject ## Internal scope - see note below
     - site:script:cookies ## Internal scope - see note below
     - site:visitor:auth ## Enable workflows related to authenticated access
-    - site:visitor:claims ## Expose visitor claims to webframes
     - site:adaptive:read ## Read claims available from Adaptive Content
     - site:adaptive:write ## Write claims avaiable to Adaptive Content
     # OpenAPI

--- a/docs/integrations/configurations.md
+++ b/docs/integrations/configurations.md
@@ -99,7 +99,6 @@ The scopes your integration has permissions for.
     - site:script:cookies ## Internal scope - see note below
     - site:visitor:auth ## Enable workflows related to authenticated access
     - site:visitor:claims ## Expose visitor claims to webframes
-    - site:page:context ## Expose the current page (id, path, title) to webframes
     - site:adaptive:read ## Read claims available from Adaptive Content
     - site:adaptive:write ## Write claims avaiable to Adaptive Content
     # OpenAPI

--- a/docs/integrations/configurations.md
+++ b/docs/integrations/configurations.md
@@ -98,6 +98,8 @@ The scopes your integration has permissions for.
     - site:script:inject ## Internal scope - see note below
     - site:script:cookies ## Internal scope - see note below
     - site:visitor:auth ## Enable workflows related to authenticated access
+    - site:visitor:claims ## Expose visitor claims to webframes
+    - site:page:context ## Expose the current page (id, path, title) to webframes
     - site:adaptive:read ## Read claims available from Adaptive Content
     - site:adaptive:write ## Write claims avaiable to Adaptive Content
     # OpenAPI

--- a/docs/integrations/contentkit/interactivity.md
+++ b/docs/integrations/contentkit/interactivity.md
@@ -91,46 +91,11 @@ window.addEventListener("message", (event) => {
 });
 ```
 
-## Page and visitor context
-
-GitBook injects contextual information about the current site into the webframe `state`, alongside the values you bind through the `data` prop:
-
-- `state.page` — the current page as `{ id, path, title }`. Always available.
-- `state.visitor` — the visitor claims, when the integration has the `site:visitor:claims` [scope](../configurations.md#scopes).
-
-This context is delivered client-side through the same `message` event as your bound `data`, so it does not change how the integration block is cached:
-
-```js
-window.addEventListener("message", (event) => {
-    const state = event.data?.state;
-    if (!state) return;
-
-    if (state.page) {
-        const { id, path, title } = state.page;
-        // e.g. build a link to a sibling page from `path`
-    }
-});
-```
-
 ## Navigating to another page
 
-A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action. A destination is addressed either by its page ID or by its path, and navigation always stays within the current site:
-
-- `pageId` (recommended) — resolved against the site's page tree, so it always lands on a real page. Resolution is scoped to the current space, so a page in a different section or space must be addressed by `path`.
-- `path` — resolved relative to the site root (the part after your site's base URL), so it can point to a page in any section or space of the site.
-
-You can also pass an optional `anchor` to scroll to a heading within the target page.
+A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action. The `path` is resolved relative to the site root (the part after your site's base URL), so it can point to a page in any section or space of the site, and navigation always stays within it. You can also pass an optional `anchor` to scroll to a heading within the target page:
 
 ```js
-// By page ID (recommended)
-window.parent.postMessage({
-    action: {
-        action: '@webframe.navigate',
-        pageId: 'xxardBqcRDgUCLxS',
-    },
-}, '*');
-
-// By path, optionally scrolling to a heading anchor
 window.parent.postMessage({
     action: {
         action: '@webframe.navigate',

--- a/docs/integrations/contentkit/interactivity.md
+++ b/docs/integrations/contentkit/interactivity.md
@@ -114,7 +114,7 @@ window.addEventListener("message", (event) => {
 
 ## Navigating to another page
 
-A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action with the target page `path` (the same format as `state.page.path`):
+A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action. The `path` is resolved relative to the site root (the part after your site's base URL), so it can point to a page in any section or space of the site:
 
 ```js
 window.parent.postMessage({
@@ -125,7 +125,7 @@ window.parent.postMessage({
 }, '*');
 ```
 
-GitBook resolves the path within the current space, so navigation always stays inside the site.
+The path is always resolved within the current site, so navigation stays inside it.
 
 ## Webframes and actions
 

--- a/docs/integrations/contentkit/interactivity.md
+++ b/docs/integrations/contentkit/interactivity.md
@@ -114,18 +114,31 @@ window.addEventListener("message", (event) => {
 
 ## Navigating to another page
 
-A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action. The `path` is resolved relative to the site root (the part after your site's base URL), so it can point to a page in any section or space of the site:
+A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action. A destination is addressed either by its page ID or by its path, and navigation always stays within the current site:
+
+- `pageId` (recommended) — resolved against the site's page tree, so it always lands on a real page. Resolution is scoped to the current space, so a page in a different section or space must be addressed by `path`.
+- `path` — resolved relative to the site root (the part after your site's base URL), so it can point to a page in any section or space of the site.
+
+You can also pass an optional `anchor` to scroll to a heading within the target page.
 
 ```js
+// By page ID (recommended)
+window.parent.postMessage({
+    action: {
+        action: '@webframe.navigate',
+        pageId: 'xxardBqcRDgUCLxS',
+    },
+}, '*');
+
+// By path, optionally scrolling to a heading anchor
 window.parent.postMessage({
     action: {
         action: '@webframe.navigate',
         path: 'guides/getting-started',
+        anchor: 'installation',
     },
 }, '*');
 ```
-
-The path is always resolved within the current site, so navigation stays inside it.
 
 ## Webframes and actions
 

--- a/docs/integrations/contentkit/interactivity.md
+++ b/docs/integrations/contentkit/interactivity.md
@@ -93,25 +93,39 @@ window.addEventListener("message", (event) => {
 
 ## Page and visitor context
 
-In addition to the values you bind through the `data` prop, GitBook injects contextual information about the current site into the webframe `state`, as long as your integration requests the matching [scope](../configurations.md#scopes):
+GitBook injects contextual information about the current site into the webframe `state`, alongside the values you bind through the `data` prop:
 
-- `state.page` — the current page as `{ id, path, title }`, when the integration has the `site:page:context` scope.
-- `state.visitor` — the visitor claims, when the integration has the `site:visitor:claims` scope.
+- `state.page` — the current page as `{ id, path, title }`. Always available.
+- `state.visitor` — the visitor claims, when the integration has the `site:visitor:claims` [scope](../configurations.md#scopes).
 
-This context is delivered client-side through the same `message` event as your bound `data`, so requesting it does not change how the integration block is cached:
+This context is delivered client-side through the same `message` event as your bound `data`, so it does not change how the integration block is cached:
 
 ```js
 window.addEventListener("message", (event) => {
     const state = event.data?.state;
     if (!state) return;
 
-    // Current page — only present when the integration has the `site:page:context` scope.
     if (state.page) {
         const { id, path, title } = state.page;
         // e.g. build a link to a sibling page from `path`
     }
 });
 ```
+
+## Navigating to another page
+
+A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action with the target page `path` (the same format as `state.page.path`):
+
+```js
+window.parent.postMessage({
+    action: {
+        action: '@webframe.navigate',
+        path: 'guides/getting-started',
+    },
+}, '*');
+```
+
+GitBook resolves the path within the current space, so navigation always stays inside the site.
 
 ## Webframes and actions
 

--- a/docs/integrations/contentkit/interactivity.md
+++ b/docs/integrations/contentkit/interactivity.md
@@ -91,6 +91,28 @@ window.addEventListener("message", (event) => {
 });
 ```
 
+## Page and visitor context
+
+In addition to the values you bind through the `data` prop, GitBook injects contextual information about the current site into the webframe `state`, as long as your integration requests the matching [scope](../configurations.md#scopes):
+
+- `state.page` — the current page as `{ id, path, title }`, when the integration has the `site:page:context` scope.
+- `state.visitor` — the visitor claims, when the integration has the `site:visitor:claims` scope.
+
+This context is delivered client-side through the same `message` event as your bound `data`, so requesting it does not change how the integration block is cached:
+
+```js
+window.addEventListener("message", (event) => {
+    const state = event.data?.state;
+    if (!state) return;
+
+    // Current page — only present when the integration has the `site:page:context` scope.
+    if (state.page) {
+        const { id, path, title } = state.page;
+        // e.g. build a link to a sibling page from `path`
+    }
+});
+```
+
 ## Webframes and actions
 
 Webframes are powerful elements to integrate in GitBook external applications or complete UI. Passing data to the webframe can be done using the `data` prop. But the webframe also needs to be able to communicate data back to the top component. It can be achieved using the `window.postMessage`:

--- a/docs/integrations/development/contentkit/reference.md
+++ b/docs/integrations/development/contentkit/reference.md
@@ -264,6 +264,8 @@ If you need a copy button, only add it when your integration has a supported way
 | `buttons`       | `Array<Button>`          | Overlay buttons          |
 | `data`          | `Record<string, string>` | State dependencies       |
 
+The `data` values, together with GitBook-provided context, reach the frame through the `message` event as `event.data.state`. GitBook reserves two keys in `state`: `page` (`{ id, path, title }` of the current page, with the `site:page:context` scope) and `visitor` (visitor claims, with the `site:visitor:claims` scope). See [Interactivity](../../contentkit/interactivity.md#page-and-visitor-context).
+
 #### `select`
 
 ```tsx

--- a/docs/integrations/development/contentkit/reference.md
+++ b/docs/integrations/development/contentkit/reference.md
@@ -264,7 +264,7 @@ If you need a copy button, only add it when your integration has a supported way
 | `buttons`       | `Array<Button>`          | Overlay buttons          |
 | `data`          | `Record<string, string>` | State dependencies       |
 
-The `data` values, together with GitBook-provided context, reach the frame through the `message` event as `event.data.state`. GitBook reserves two keys in `state`: `page` (`{ id, path, title }` of the current page, always available) and `visitor` (visitor claims, with the `site:visitor:claims` scope). A webframe can also navigate the reader to another page by posting a `@webframe.navigate` action. See [Interactivity](../../contentkit/interactivity.md#page-and-visitor-context).
+The `data` values, together with GitBook-provided context, reach the frame through the `message` event as `event.data.state`. GitBook reserves two keys in `state`: `page` (`{ id, path, title }` of the current page, always available) and `visitor` (visitor claims, with the `site:visitor:claims` scope). A webframe can also navigate the reader to another page by posting a `@webframe.navigate` action, addressing the destination by `pageId` or `path`. See [Interactivity](../../contentkit/interactivity.md#page-and-visitor-context).
 
 #### `select`
 

--- a/docs/integrations/development/contentkit/reference.md
+++ b/docs/integrations/development/contentkit/reference.md
@@ -264,7 +264,7 @@ If you need a copy button, only add it when your integration has a supported way
 | `buttons`       | `Array<Button>`          | Overlay buttons          |
 | `data`          | `Record<string, string>` | State dependencies       |
 
-The `data` values, together with GitBook-provided context, reach the frame through the `message` event as `event.data.state`. GitBook reserves two keys in `state`: `page` (`{ id, path, title }` of the current page, always available) and `visitor` (visitor claims, with the `site:visitor:claims` scope). A webframe can also navigate the reader to another page by posting a `@webframe.navigate` action, addressing the destination by `pageId` or `path`. See [Interactivity](../../contentkit/interactivity.md#page-and-visitor-context).
+The `data` values reach the frame through the `message` event as `event.data.state`. A webframe can also navigate the reader to another page in the site by posting a `@webframe.navigate` action with a `path`. See [Interactivity](../../contentkit/interactivity.md#navigating-to-another-page).
 
 #### `select`
 

--- a/docs/integrations/development/contentkit/reference.md
+++ b/docs/integrations/development/contentkit/reference.md
@@ -264,7 +264,7 @@ If you need a copy button, only add it when your integration has a supported way
 | `buttons`       | `Array<Button>`          | Overlay buttons          |
 | `data`          | `Record<string, string>` | State dependencies       |
 
-The `data` values, together with GitBook-provided context, reach the frame through the `message` event as `event.data.state`. GitBook reserves two keys in `state`: `page` (`{ id, path, title }` of the current page, with the `site:page:context` scope) and `visitor` (visitor claims, with the `site:visitor:claims` scope). See [Interactivity](../../contentkit/interactivity.md#page-and-visitor-context).
+The `data` values, together with GitBook-provided context, reach the frame through the `message` event as `event.data.state`. GitBook reserves two keys in `state`: `page` (`{ id, path, title }` of the current page, always available) and `visitor` (visitor claims, with the `site:visitor:claims` scope). A webframe can also navigate the reader to another page by posting a `@webframe.navigate` action. See [Interactivity](../../contentkit/interactivity.md#page-and-visitor-context).
 
 #### `select`
 

--- a/docs/integrations/guides/interactivity.md
+++ b/docs/integrations/guides/interactivity.md
@@ -95,6 +95,28 @@ window.addEventListener("message", (event) => {
 });
 ```
 
+### Page and visitor context
+
+In addition to the values you bind through the `data` prop, GitBook injects contextual information about the current site into the webframe `state`, as long as your integration requests the matching [scope](../configurations.md#scopes):
+
+- `state.page` — the current page as `{ id, path, title }`, when the integration has the `site:page:context` scope.
+- `state.visitor` — the visitor claims, when the integration has the `site:visitor:claims` scope.
+
+This context is delivered client-side through the same `message` event as your bound `data`, so requesting it does not change how the integration block is cached:
+
+```js
+window.addEventListener("message", (event) => {
+    const state = event.data?.state;
+    if (!state) return;
+
+    // Current page — only present when the integration has the `site:page:context` scope.
+    if (state.page) {
+        const { id, path, title } = state.page;
+        // e.g. build a link to a sibling page from `path`
+    }
+});
+```
+
 ### Editable blocks
 
 Some blocks might be static or only generated from link unfurling, but most blocks are designed to be editable by the user. Editable means that the user can interact with the blocks to change its properties.

--- a/docs/integrations/guides/interactivity.md
+++ b/docs/integrations/guides/interactivity.md
@@ -95,46 +95,11 @@ window.addEventListener("message", (event) => {
 });
 ```
 
-### Page and visitor context
-
-GitBook injects contextual information about the current site into the webframe `state`, alongside the values you bind through the `data` prop:
-
-- `state.page` — the current page as `{ id, path, title }`. Always available.
-- `state.visitor` — the visitor claims, when the integration has the `site:visitor:claims` [scope](../configurations.md#scopes).
-
-This context is delivered client-side through the same `message` event as your bound `data`, so it does not change how the integration block is cached:
-
-```js
-window.addEventListener("message", (event) => {
-    const state = event.data?.state;
-    if (!state) return;
-
-    if (state.page) {
-        const { id, path, title } = state.page;
-        // e.g. build a link to a sibling page from `path`
-    }
-});
-```
-
 ### Navigating to another page
 
-A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action. A destination is addressed either by its page ID or by its path, and navigation always stays within the current site:
-
-- `pageId` (recommended) — resolved against the site's page tree, so it always lands on a real page. Resolution is scoped to the current space, so a page in a different section or space must be addressed by `path`.
-- `path` — resolved relative to the site root (the part after your site's base URL), so it can point to a page in any section or space of the site.
-
-You can also pass an optional `anchor` to scroll to a heading within the target page.
+A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action. The `path` is resolved relative to the site root (the part after your site's base URL), so it can point to a page in any section or space of the site, and navigation always stays within it. You can also pass an optional `anchor` to scroll to a heading within the target page:
 
 ```js
-// By page ID (recommended)
-window.parent.postMessage({
-    action: {
-        action: '@webframe.navigate',
-        pageId: 'xxardBqcRDgUCLxS',
-    },
-}, '*');
-
-// By path, optionally scrolling to a heading anchor
 window.parent.postMessage({
     action: {
         action: '@webframe.navigate',

--- a/docs/integrations/guides/interactivity.md
+++ b/docs/integrations/guides/interactivity.md
@@ -97,25 +97,39 @@ window.addEventListener("message", (event) => {
 
 ### Page and visitor context
 
-In addition to the values you bind through the `data` prop, GitBook injects contextual information about the current site into the webframe `state`, as long as your integration requests the matching [scope](../configurations.md#scopes):
+GitBook injects contextual information about the current site into the webframe `state`, alongside the values you bind through the `data` prop:
 
-- `state.page` — the current page as `{ id, path, title }`, when the integration has the `site:page:context` scope.
-- `state.visitor` — the visitor claims, when the integration has the `site:visitor:claims` scope.
+- `state.page` — the current page as `{ id, path, title }`. Always available.
+- `state.visitor` — the visitor claims, when the integration has the `site:visitor:claims` [scope](../configurations.md#scopes).
 
-This context is delivered client-side through the same `message` event as your bound `data`, so requesting it does not change how the integration block is cached:
+This context is delivered client-side through the same `message` event as your bound `data`, so it does not change how the integration block is cached:
 
 ```js
 window.addEventListener("message", (event) => {
     const state = event.data?.state;
     if (!state) return;
 
-    // Current page — only present when the integration has the `site:page:context` scope.
     if (state.page) {
         const { id, path, title } = state.page;
         // e.g. build a link to a sibling page from `path`
     }
 });
 ```
+
+### Navigating to another page
+
+A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action with the target page `path` (the same format as `state.page.path`):
+
+```js
+window.parent.postMessage({
+    action: {
+        action: '@webframe.navigate',
+        path: 'guides/getting-started',
+    },
+}, '*');
+```
+
+GitBook resolves the path within the current space, so navigation always stays inside the site.
 
 ### Editable blocks
 

--- a/docs/integrations/guides/interactivity.md
+++ b/docs/integrations/guides/interactivity.md
@@ -118,7 +118,7 @@ window.addEventListener("message", (event) => {
 
 ### Navigating to another page
 
-A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action with the target page `path` (the same format as `state.page.path`):
+A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action. The `path` is resolved relative to the site root (the part after your site's base URL), so it can point to a page in any section or space of the site:
 
 ```js
 window.parent.postMessage({
@@ -129,7 +129,7 @@ window.parent.postMessage({
 }, '*');
 ```
 
-GitBook resolves the path within the current space, so navigation always stays inside the site.
+The path is always resolved within the current site, so navigation stays inside it.
 
 ### Editable blocks
 

--- a/docs/integrations/guides/interactivity.md
+++ b/docs/integrations/guides/interactivity.md
@@ -118,18 +118,31 @@ window.addEventListener("message", (event) => {
 
 ### Navigating to another page
 
-A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action. The `path` is resolved relative to the site root (the part after your site's base URL), so it can point to a page in any section or space of the site:
+A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action. A destination is addressed either by its page ID or by its path, and navigation always stays within the current site:
+
+- `pageId` (recommended) — resolved against the site's page tree, so it always lands on a real page. Resolution is scoped to the current space, so a page in a different section or space must be addressed by `path`.
+- `path` — resolved relative to the site root (the part after your site's base URL), so it can point to a page in any section or space of the site.
+
+You can also pass an optional `anchor` to scroll to a heading within the target page.
 
 ```js
+// By page ID (recommended)
+window.parent.postMessage({
+    action: {
+        action: '@webframe.navigate',
+        pageId: 'xxardBqcRDgUCLxS',
+    },
+}, '*');
+
+// By path, optionally scrolling to a heading anchor
 window.parent.postMessage({
     action: {
         action: '@webframe.navigate',
         path: 'guides/getting-started',
+        anchor: 'installation',
     },
 }, '*');
 ```
-
-The path is always resolved within the current site, so navigation stays inside it.
 
 ### Editable blocks
 


### PR DESCRIPTION
## What

Documents how an integration block webframe can navigate the reader to another page in the site, via the postMessage protocol:

- `@webframe.navigate` — navigate the reader to another page in the site, addressed by `path` (with an optional `anchor`). Resolved relative to the site root, so it can point to a page in any section or space of the site.

## Why

Part of **RND-11604**. Frontend implementation: GitbookIO/gitbook#4362.

## Changes

- `contentkit/interactivity.md` + `guides/interactivity.md`: new "Navigating to another page" section.
- `development/contentkit/reference.md`: note the navigate action in the `webframe` reference.

Docs-only; no changeset (docs are not a versioned package in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
