### PR TITLE
Fix OneTrust consent not syncing when visitor accepts cookies (RND-11843)

### DIFF
--- a/.changeset/onetrust-consent-sync.md
+++ b/.changeset/onetrust-consent-sync.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-onetrust': patch
+---
+
+Fix OneTrust consent not being recorded when a visitor accepts cookies. The banner's initial load no longer emits a premature rejection before the visitor answers, and an explicit Accept/Reject now always syncs to GitBook even if a prior consent decision was already recorded.

--- a/integrations/onetrust/src/script.raw.js
+++ b/integrations/onetrust/src/script.raw.js
@@ -153,7 +153,7 @@
                     if (
                         !hasRecordedConsent &&
                         w.OnetrustActiveGroups !== undefined &&
-                        typeof w.OneTrust !== 'undefined' &&
+                        w.OneTrust !== undefined &&
                         typeof w.OneTrust.IsAlertBoxClosed === 'function' &&
                         w.OneTrust.IsAlertBoxClosed()
                     ) {

--- a/integrations/onetrust/src/script.raw.js
+++ b/integrations/onetrust/src/script.raw.js
@@ -147,9 +147,16 @@
                 previousOptanonWrapper && previousOptanonWrapper();
                 try {
                     w.dispatchEvent(new Event('onetrust-banner-loaded'));
-                    // Emit initial consent for returning visitors (OnetrustActiveGroups
-                    // is populated from stored consent; OTConsentApplied won't fire)
-                    if (!hasRecordedConsent && w.OnetrustActiveGroups !== undefined) {
+                    // Re-sync stored consent for returning visitors, but only once the
+                    // banner has actually been answered. Before that, OnetrustActiveGroups
+                    // holds the essential-only default and emitConsent would wrongly reject.
+                    if (
+                        !hasRecordedConsent &&
+                        w.OnetrustActiveGroups !== undefined &&
+                        typeof w.OneTrust !== 'undefined' &&
+                        typeof w.OneTrust.IsAlertBoxClosed === 'function' &&
+                        w.OneTrust.IsAlertBoxClosed()
+                    ) {
                         emitConsent();
                     }
                 } catch (e) {}
@@ -165,11 +172,11 @@
                 }
             };
 
-            // OTConsentApplied fires when user clicks Accept/Reject
+            // OTConsentApplied fires when the user clicks Accept/Reject. A live choice is
+            // always a fresh decision, so it must re-sync even if a stale consent cookie
+            // was already recorded (e.g. a default-deny) when the page loaded.
             w.addEventListener('OTConsentApplied', function () {
-                if (!hasRecordedConsent) {
-                    emitConsent();
-                }
+                emitConsent();
             });
         });
     }


### PR DESCRIPTION
Follow-up to RND-10728. Customers reported Segment still not firing after clicking "Accept All" in OneTrust (notably in Chrome), even with the consent-gating fix in place.

The root cause is not a browser difference — it's the OneTrust → GitBook consent bridge leaving `__gitbook_cookie_granted` stuck, so every consent-gated integration (Segment, Google Analytics, Intercom, …) stayed silent. Two reinforcing defects in `script.raw.js`:

- **Premature rejection on load.** The `OptanonWrapper` re-sync ran as soon as `OnetrustActiveGroups` was defined. On a first visit that global holds the essential-only default (`,C0001,`) *before the visitor answers*, so the bridge called `onReject()` and recorded a spurious "no". Now guarded by `OneTrust.IsAlertBoxClosed()`, matching the existing pattern in `applyGPCBanner`.
- **Stale gate swallows the real click.** The `OTConsentApplied` listener was gated on the once-captured `hasRecordedConsent` snapshot, so an explicit Accept/Reject was ignored whenever a decision (including the spurious one above) was already recorded — leaving consent permanently stuck until cookies were cleared. A live user choice now always re-syncs.

Verified by exercising the actual `script.raw.js` against the key scenarios (first-time accept/reject, stale-cookie accept, returning-visitor re-sync, no-interaction): the pre-fix script fails the stuck-consent case; the fix passes all.

Note: with the bridge now correct, a Brave visitor (GPC on by default → OneTrust reject path) will not fire Segment unless they explicitly accept — this is correct consent behavior.