### PR TITLE
Pin npm to 11.x to fix release publish (sigstore bundling bug)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,9 +29,11 @@ jobs:
                   # npm trusted publishing requires npm 11.5.1+ (Node 22.14.0+)
                   node-version: '24'
                   registry-url: 'https://registry.npmjs.org'
-            # Ensure npm 11.5.1 or later is installed
+            # Ensure npm 11.5.1 or later is installed.
+            # Pinned to the 11.x line: npm 12.0.0 ships without the bundled `sigstore`
+            # module, which breaks provenance publishing (npm/cli#9722).
             - name: Update npm
-              run: npm install -g npm@latest
+              run: npm install -g npm@11
             - name: Setup bun
               uses: oven-sh/setup-bun@v2
               with:


### PR DESCRIPTION
## Problem
The `Release` job fails at `changeset publish` with `npm error Cannot find module 'sigstore'` (from `libnpmpublish/lib/provenance.js`).

npm **12.0.0** (released 2026-07-08) ships without the bundled `sigstore` module that `libnpmpublish` requires to generate provenance. The workflow ran `npm install -g npm@latest`, picking up the broken 12.0.0, so publishing with `NPM_CONFIG_PROVENANCE: true` crashes. Upstream: npm/cli#9722.

The crash happens before any package is pushed, so `@gitbook/api@0.187.0` (bumped by #1236) never reached npm.