### PR TITLE
Document webframe page and visitor context

### DIFF
--- a/docs/integrations/configurations.md
+++ b/docs/integrations/configurations.md
@@ -98,6 +98,7 @@ The scopes your integration has permissions for.
     - site:script:inject ## Internal scope - see note below
     - site:script:cookies ## Internal scope - see note below
     - site:visitor:auth ## Enable workflows related to authenticated access
+    - site:visitor:claims ## Expose visitor claims to webframes
     - site:adaptive:read ## Read claims available from Adaptive Content
     - site:adaptive:write ## Write claims avaiable to Adaptive Content
     # OpenAPI

--- a/docs/integrations/contentkit/interactivity.md
+++ b/docs/integrations/contentkit/interactivity.md
@@ -91,6 +91,27 @@ window.addEventListener("message", (event) => {
 });
 ```
 
+## Page and visitor context
+
+GitBook injects contextual information about the current site into the webframe `state`, alongside the values you bind through the `data` prop:
+
+- `state.page` — the current page as `{ id, path, title }`. Always available.
+- `state.visitor` — the visitor claims, when the integration has the `site:visitor:claims` [scope](../configurations.md#scopes).
+
+This context is delivered client-side through the same `message` event as your bound `data`, so it does not change how the integration block is cached:
+
+```js
+window.addEventListener("message", (event) => {
+    const state = event.data?.state;
+    if (!state) return;
+
+    if (state.page) {
+        const { id, path, title } = state.page;
+        // e.g. build a link to a sibling page from `path`
+    }
+});
+```
+
 ## Navigating to another page
 
 A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action. The `path` is resolved relative to the site root (the part after your site's base URL), so it can point to a page in any section or space of the site, and navigation always stays within it. You can also pass an optional `anchor` to scroll to a heading within the target page:

--- a/docs/integrations/development/contentkit/reference.md
+++ b/docs/integrations/development/contentkit/reference.md
@@ -264,7 +264,7 @@ If you need a copy button, only add it when your integration has a supported way
 | `buttons`       | `Array<Button>`          | Overlay buttons          |
 | `data`          | `Record<string, string>` | State dependencies       |
 
-The `data` values reach the frame through the `message` event as `event.data.state`. A webframe can also navigate the reader to another page in the site by posting a `@webframe.navigate` action with a `path`. See [Interactivity](../../contentkit/interactivity.md#navigating-to-another-page).
+The `data` values, together with GitBook-provided context, reach the frame through the `message` event as `event.data.state`. GitBook reserves two keys in `state`: `page` (`{ id, path, title }` of the current page, always available) and `visitor` (visitor claims, with the `site:visitor:claims` scope). A webframe can also navigate the reader to another page in the site by posting a `@webframe.navigate` action with a `path`. See [Interactivity](../../contentkit/interactivity.md#page-and-visitor-context).
 
 #### `select`
 

--- a/docs/integrations/guides/interactivity.md
+++ b/docs/integrations/guides/interactivity.md
@@ -95,6 +95,27 @@ window.addEventListener("message", (event) => {
 });
 ```
 
+### Page and visitor context
+
+GitBook injects contextual information about the current site into the webframe `state`, alongside the values you bind through the `data` prop:
+
+- `state.page` — the current page as `{ id, path, title }`. Always available.
+- `state.visitor` — the visitor claims, when the integration has the `site:visitor:claims` [scope](../configurations.md#scopes).
+
+This context is delivered client-side through the same `message` event as your bound `data`, so it does not change how the integration block is cached:
+
+```js
+window.addEventListener("message", (event) => {
+    const state = event.data?.state;
+    if (!state) return;
+
+    if (state.page) {
+        const { id, path, title } = state.page;
+        // e.g. build a link to a sibling page from `path`
+    }
+});
+```
+
 ### Navigating to another page
 
 A webframe can navigate the reader to another page in the site by posting a `@webframe.navigate` action. The `path` is resolved relative to the site root (the part after your site's base URL), so it can point to a page in any section or space of the site, and navigation always stays within it. You can also pass an optional `anchor` to scroll to a heading within the target page:


### PR DESCRIPTION
## What

Document the contextual `state` GitBook injects into an integration block webframe, alongside the values bound through the `data` prop:

- `state.page` — the current page as `{ id, path, title }`. Always available.
- `state.visitor` — the visitor claims, when the integration has the `site:visitor:claims` scope.

Also restores the `site:visitor:claims` scope entry in the configuration reference.

## Why

**RND-12101** — an integration's webframe needs to be aware of the page it is rendered on. Frontend implementation: GitbookIO/gitbook#4411.

## Changes

- `contentkit/interactivity.md` + `guides/interactivity.md`: new "Page and visitor context" section.
- `development/contentkit/reference.md`: note `state.page` / `state.visitor` in the `webframe` reference.
- `configurations.md`: restore the `site:visitor:claims` scope.

Docs-only; no changeset (docs are not a versioned package in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
