### PR TITLE
Docs: fix webframe source prop in interactivity examples

### DIFF
--- a/docs/integrations/contentkit/interactivity.md
+++ b/docs/integrations/contentkit/interactivity.md
@@ -69,7 +69,7 @@ createComponent({
                     <textinput state="content" />
                     <divider />
                     <webframe
-                        source={{ uri: '/iframe.html' }}
+                        source={{ url: '/iframe.html' }}
                         data={{
                             content: element.dynamicState('content')
                         }}

--- a/docs/integrations/guides/interactivity.md
+++ b/docs/integrations/guides/interactivity.md
@@ -73,7 +73,7 @@ createComponent({
                     <textinput state="content" />
                     <divider />
                     <webframe
-                        source={{ uri: '/iframe.html' }}
+                        source={{ url: '/iframe.html' }}
                         data={{
                             content: element.dynamicState('content')
                         }}


### PR DESCRIPTION
The dynamic binding examples in both interactivity pages document the webframe source as `source={{ uri: '/iframe.html' }}`, but the `source` object takes a `url` field:

```ts
export interface ContentKitWebFrame {
  type: "webframe";
  aspectRatio?: number;
  /** Content to load in the frame. */
  source: {
    url: string;
  };
  ...
}
```

(`packages/api/src/client.ts`)

Copy-pasting either example gives you a webframe with nothing to load. Every webframe integration in this repo already uses `url` — `lucid`, `toucantoco`, `arcade`, `plantuml`, `runkit`, `marketo`.

Changes `uri` to `url` in:
- `docs/integrations/contentkit/interactivity.md`
- `docs/integrations/guides/interactivity.md`