### PR TITLE
Update Google Analytics configuration summary

### DIFF
--- a/.changeset/tired-berries-sleep.md
+++ b/.changeset/tired-berries-sleep.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-googleanalytics': patch
+---
+
+Update summary to better configure integration

--- a/integrations/googleanalytics/gitbook-manifest.yaml
+++ b/integrations/googleanalytics/gitbook-manifest.yaml
@@ -46,7 +46,26 @@ summary: |
 
     # Configure
 
-    GitBook admins can enable the Google Analytics integration by navigating to organization settings.  The integration can be enabled on single or multiple spaces available publicly.
+    Configure the integration for each site you want to track. You can add your measurement ID from the sidebar or from site settings.
+
+    This covers GA4 properties, which use a measurement ID in the format G-XXXXXXXXXX. If you're still using a Universal Analytics property (UA-XXXXXXXXX-Y), upgrade to GA4 first — Google sunset Universal Analytics in 2024.
+
+    **Add the measurement ID from the sidebar**
+
+    1. Open the Integrations tab in the sidebar.
+    2. Find Google Analytics in the list of installed integrations and click Configuration.
+    3. Click Pick a site and select the site you want to track.
+    4. Open the Actions menu next to the site name and click Configure in site.
+    5. Add your measurement ID (G-XXXXXXXXXX) in the Measurement ID field.
+
+    **Add the measurement ID from site settings**
+
+    1. Open the site you want to track.
+    2. Click Integrations in the top right.
+    3. Find Google Analytics and click the settings icon.
+    4. Add your measurement ID (G-XXXXXXXXXX) in the Measurement ID field.
+
+    Your site will start sending data to Google Analytics. Data can take up to 48 hours to appear in your dashboard.
 categories:
     - analytics
 configurations:


### PR DESCRIPTION
Noticed we had a dedicated docs page on how to configure this integration, while the summary of this integration wasn’t descriptive at all. This PR adds the configuration steps to the summary.