### PR TITLE
Support Amplitude projects with EU data residency

### DIFF
--- a/.changeset/witty-regions-travel.md
+++ b/.changeset/witty-regions-travel.md
@@ -1,0 +1,5 @@
+---
+"@gitbook/integration-amplitude": minor
+---
+
+Support Amplitude projects with EU data residency: a new "Server Region" option loads the SDK from the EU CDN and routes events to the EU endpoint. Previously the injected loader always used the US CDN, which rejects EU API keys with 401 "Invalid Key.", so the integration silently never initialized for EU projects.

--- a/integrations/amplitude/gitbook-manifest.yaml
+++ b/integrations/amplitude/gitbook-manifest.yaml
@@ -15,10 +15,13 @@ scopes:
     - site:script:cookies
 contentSecurityPolicy:
     script-src: |
-        https://cdn.amplitude.com;
+        https://cdn.amplitude.com
+        https://cdn.eu.amplitude.com;
     connect-src: |
         cdn.amplitude.com;
         api2.amplitude.com;
+        cdn.eu.amplitude.com;
+        api.eu.amplitude.com;
 summary: |
     # Overview
 
@@ -43,6 +46,14 @@ configurations:
                 type: string
                 title: Amplitude API Key
                 description: Your Amplitude API Key
+            server_region:
+                type: string
+                title: Server Region
+                description: Data residency region of your Amplitude project (Organization Settings > Projects)
+                default: Standard (US)
+                enum:
+                    - Standard (US)
+                    - EU
             server_url:
                 type: string
                 title: Server URL

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -12,6 +12,7 @@
     },
     "scripts": {
         "typecheck": "tsc --noEmit",
+        "test": "bun test",
         "publish-integrations-staging": "gitbook publish .",
         "publish-integrations": "gitbook publish ."
     }

--- a/integrations/amplitude/src/amplitudeScript.raw.js
+++ b/integrations/amplitude/src/amplitudeScript.raw.js
@@ -1,4 +1,4 @@
-(function (w, d, s, apiKey, initConfigJson) {
+(function (w, d, s, apiKey, cdnHost, initConfigJson) {
     const GRANTED_COOKIE = '__gitbook_cookie_granted';
 
     function getCookie(cname) {
@@ -26,7 +26,7 @@
     // Create and inject the Amplitude CDN script
     var j = d.createElement(s);
     j.async = true;
-    j.src = 'https://cdn.amplitude.com/script/' + apiKey + '.js';
+    j.src = 'https://' + cdnHost + '/script/' + apiKey + '.js';
     j.referrerPolicy = 'no-referrer-when-downgrade';
     j.onload = function () {
         window.amplitude.add(window.sessionReplay.plugin({ sampleRate: 1 }));
@@ -34,4 +34,4 @@
         window.amplitude.init(apiKey, initConfig);
     };
     f.parentNode.insertBefore(j, f);
-})(window, document, 'script', '<TO_REPLACE>', '<TO_REPLACE_INIT_CONFIG>');
+})(window, document, 'script', '<TO_REPLACE>', '<TO_REPLACE_CDN_HOST>', '<TO_REPLACE_INIT_CONFIG>');

--- a/integrations/amplitude/src/index.ts
+++ b/integrations/amplitude/src/index.ts
@@ -8,12 +8,28 @@ import {
 import script from './amplitudeScript.raw.js';
 
 const DEFAULT_SERVER_URL = 'https://api2.amplitude.com/2/httpapi';
+const EU_SERVER_URL = 'https://api.eu.amplitude.com/2/httpapi';
+
+/**
+ * Maps server region selection to the Amplitude script CDN host.
+ * Projects with EU data residency are only served by the EU CDN,
+ * the US CDN responds with 401 "Invalid Key." for them (and vice versa).
+ */
+function getCdnHost(region: string | undefined): string {
+    switch (region) {
+        case 'EU':
+            return 'cdn.eu.amplitude.com';
+        default:
+            return 'cdn.amplitude.com';
+    }
+}
 
 type AmplitudeRuntimeContext = RuntimeContext<
     RuntimeEnvironment<
         {},
         {
             amplitude_api_key?: string;
+            server_region?: string;
             server_url?: string;
             autocapture_attribution?: boolean;
             autocapture_page_views?: boolean;
@@ -40,9 +56,16 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
         return;
     }
 
+    const isEU = config?.server_region === 'EU';
     const serverUrl = config?.server_url ?? DEFAULT_SERVER_URL;
+    // The default server URL of the selected region is redundant: the SDK
+    // derives it from serverZone. Only a genuinely custom URL (e.g. a proxy)
+    // needs to be passed on.
+    const isRegionDefaultServerUrl =
+        serverUrl === DEFAULT_SERVER_URL || (isEU && serverUrl === EU_SERVER_URL);
     const initConfig = {
-        ...(serverUrl !== DEFAULT_SERVER_URL ? { serverUrl } : {}),
+        ...(isEU ? { serverZone: 'EU' } : {}),
+        ...(isRegionDefaultServerUrl ? {} : { serverUrl }),
         fetchRemoteConfig: true,
         autocapture: {
             attribution: config?.autocapture_attribution ?? true,
@@ -61,6 +84,10 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
     const initConfigJson = JSON.stringify(initConfig).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 
     let scriptContent = (script as string).replace(/<TO_REPLACE>/g, amplitudeApiKey);
+    scriptContent = scriptContent.replace(
+        '<TO_REPLACE_CDN_HOST>',
+        getCdnHost(config?.server_region),
+    );
     scriptContent = scriptContent.replace('<TO_REPLACE_INIT_CONFIG>', initConfigJson);
 
     return new Response(scriptContent, {

--- a/integrations/amplitude/tests/script.test.ts
+++ b/integrations/amplitude/tests/script.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+// The gitbook CLI bundles *.raw.js imports as text (see packages/cli/src/build.ts),
+// bun test does not, so provide the file content as module mock.
+const rawScript = await Bun.file(new URL('../src/amplitudeScript.raw.js', import.meta.url)).text();
+mock.module('../src/amplitudeScript.raw.js', () => ({ default: rawScript }));
+
+const { handleFetchEvent } = await import('../src/index');
+
+async function generateScript(configuration: Record<string, unknown>): Promise<string> {
+    const response = (await handleFetchEvent(
+        {} as any,
+        {
+            environment: {
+                siteInstallation: {
+                    configuration,
+                },
+            },
+        } as any,
+    )) as Response;
+    return response.text();
+}
+
+describe('fetch_published_script', () => {
+    it('should load the SDK from the US CDN by default', async () => {
+        const script = await generateScript({ amplitude_api_key: 'fake-api-key' });
+        expect(script).toContain("'cdn.amplitude.com'");
+        expect(script).toContain("'fake-api-key'");
+        expect(script).not.toContain('serverZone');
+        expect(script).not.toContain('serverUrl');
+    });
+
+    it('should load the SDK from the EU CDN when the EU server region is selected', async () => {
+        const script = await generateScript({
+            amplitude_api_key: 'fake-api-key',
+            server_region: 'EU',
+        });
+        expect(script).toContain("'cdn.eu.amplitude.com'");
+        expect(script).toContain('"serverZone":"EU"');
+    });
+
+    it('should not pass on a server URL matching the default of the selected region', async () => {
+        const usScript = await generateScript({
+            amplitude_api_key: 'fake-api-key',
+            server_url: 'https://api2.amplitude.com/2/httpapi',
+        });
+        expect(usScript).not.toContain('serverUrl');
+
+        const euScript = await generateScript({
+            amplitude_api_key: 'fake-api-key',
+            server_region: 'EU',
+            server_url: 'https://api.eu.amplitude.com/2/httpapi',
+        });
+        expect(euScript).not.toContain('serverUrl');
+
+        const euScriptWithUsDefault = await generateScript({
+            amplitude_api_key: 'fake-api-key',
+            server_region: 'EU',
+            server_url: 'https://api2.amplitude.com/2/httpapi',
+        });
+        expect(euScriptWithUsDefault).not.toContain('serverUrl');
+    });
+
+    it('should pass on a custom server URL in any region', async () => {
+        const usScript = await generateScript({
+            amplitude_api_key: 'fake-api-key',
+            server_url: 'https://example.com/proxy/2/httpapi',
+        });
+        expect(usScript).toContain('"serverUrl":"https://example.com/proxy/2/httpapi"');
+
+        const euScript = await generateScript({
+            amplitude_api_key: 'fake-api-key',
+            server_region: 'EU',
+            server_url: 'https://example.com/proxy/2/httpapi',
+        });
+        expect(euScript).toContain('"serverUrl":"https://example.com/proxy/2/httpapi"');
+        expect(euScript).toContain('"serverZone":"EU"');
+    });
+});

--- a/integrations/amplitude/tsconfig.json
+++ b/integrations/amplitude/tsconfig.json
@@ -1,3 +1,6 @@
 {
-    "extends": "@gitbook/tsconfig/integration.json"
+    "extends": "@gitbook/tsconfig/integration.json",
+    "compilerOptions": {
+        "types": ["bun"]
+    }
 }


### PR DESCRIPTION
## Problem

The integration loads the Amplitude autocapture bundle from `https://cdn.amplitude.com/script/<API_KEY>.js` unconditionally. For Amplitude projects with **EU data residency** that CDN responds with `401 "Invalid Key."` — the loader fails silently, `amplitude.init()` is never called, and the integration tracks nothing, with no visible error to the site owner.

Repro: `curl https://cdn.amplitude.com/script/<EU_KEY>.js` → 401 "Invalid Key.", while the same key on `cdn.eu.amplitude.com` → 200.

## Fix

Adds a **Server Region** configuration option (same pattern as the Mixpanel integration): selecting EU loads the bundle from `cdn.eu.amplitude.com` and sets `serverZone: 'EU'`, so event ingestion, remote config, and session replay all use the EU endpoints. A custom Server URL (e.g. a first-party proxy) is still honored in both regions; a Server URL matching the selected region's default is omitted as redundant. Existing US installations are unaffected.

- `gitbook-manifest.yaml`: new `server_region` enum (default `Standard (US)`), EU hosts added to the CSP
- `amplitudeScript.raw.js`: CDN host is a template parameter instead of a hardcoded URL
- `index.ts`: region → CDN host mapping and `serverZone` handling
- `tests/script.test.ts`: covers US default (unchanged output), EU CDN + serverZone, region-default server URL suppression, custom server URL passthrough

## Testing

- `bun test`: 4 new tests pass; typecheck/lint/format clean
- Verified end-to-end against a live GitBook site (docs.steadybit.com) with an EU Amplitude project by injecting the exact script the updated handler generates: the EU bundle loads, session replay posts to `api-sr.eu.amplitude.com`, and events are ingested by Amplitude EU.