### PR TITLE
Release search page descriptions in @gitbook/api

### DIFF
--- a/.changeset/calm-pages-search.md
+++ b/.changeset/calm-pages-search.md
@@ -1,0 +1,6 @@
+---
+'@gitbook/api': minor
+'@gitbook/cli': patch
+---
+
+Expose page descriptions in published search results.


### PR DESCRIPTION
Adds the release metadata for the page-level published-search description introduced by [GitbookIO/gitbook-x#25061](https://github.com/GitbookIO/gitbook-x/pull/25061):

- minor release for `@gitbook/api`
- patch release for the dependent `@gitbook/cli`

The generated package build fetches `https://api.gitbook.com/openapi.yaml`. The Changesets “Version Packages” PR must therefore be merged only after gitbook-x #25061 has reached production, otherwise it would publish a client generated from the old contract.

The resulting `@gitbook/api` version will be consumed by [GitbookIO/gitbook#4537](https://github.com/GitbookIO/gitbook/pull/4537).