### PR TITLE
Update the CLI to use OAuth for integrations

### DIFF
--- a/.changeset/soft-mangos-listen.md
+++ b/.changeset/soft-mangos-listen.md
@@ -1,0 +1,5 @@
+---
+"@gitbook/cli": minor
+---
+
+Publishing integrations no longer requires a personal API token: `gitbook login` alone is now enough for the whole integration developer workflow, since the GitBook API exposes the integration developer endpoints to OAuth tokens through the new `integration:*` scopes. A session created before those scopes existed gets actionable guidance (naming the scopes the API says are missing) telling it to run `gitbook login` again, instead of a raw 403.

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@gitbook/integrations",
@@ -29,7 +30,7 @@
     },
     "integrations/amplitude": {
       "name": "@gitbook/integration-amplitude",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dependencies": {
         "@gitbook/api": "*",
         "@gitbook/runtime": "*",
@@ -66,7 +67,7 @@
     },
     "integrations/cognito": {
       "name": "@gitbook/integration-cognito",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@gitbook/api": "*",
         "@gitbook/runtime": "*",
@@ -452,7 +453,7 @@
     },
     "integrations/navattic": {
       "name": "@gitbook/integration-navattic",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@gitbook/api": "*",
         "@gitbook/runtime": "*",
@@ -464,7 +465,7 @@
     },
     "integrations/oidc": {
       "name": "@gitbook/integration-oidc",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@gitbook/api": "*",
         "@gitbook/runtime": "*",
@@ -680,7 +681,7 @@
     },
     "integrations/va-auth0": {
       "name": "@gitbook/integration-va-auth0",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@gitbook/api": "*",
         "@gitbook/runtime": "*",
@@ -694,7 +695,7 @@
     },
     "integrations/va-azure": {
       "name": "@gitbook/integration-va-azure",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@gitbook/api": "*",
         "@gitbook/runtime": "*",
@@ -708,7 +709,7 @@
     },
     "integrations/va-okta": {
       "name": "@gitbook/integration-va-okta",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@gitbook/api": "*",
         "@gitbook/runtime": "*",
@@ -774,7 +775,7 @@
     },
     "packages/api": {
       "name": "@gitbook/api",
-      "version": "0.195.0",
+      "version": "0.196.0",
       "dependencies": {
         "event-iterator": "^2.0.0",
         "eventsource-parser": "^3.0.0",
@@ -789,7 +790,7 @@
     },
     "packages/cli": {
       "name": "@gitbook/cli",
-      "version": "0.31.1",
+      "version": "0.31.2",
       "bin": {
         "gitbook": "./cli.js",
       },

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -37,8 +37,9 @@ export interface OAuthSession {
 /**
  * Authentication configuration for a single environment.
  *
- * A personal API token and a browser (OAuth) session can both be stored at once: the token is
- * required for publishing integrations, while the OAuth session covers the rest of the API.
+ * A personal API token (`gitbook auth`) and a browser (OAuth) session (`gitbook login`) are both
+ * fully supported, and which one to use is up to the user. Both can be stored at once; when they
+ * are, the OAuth session is the one sent to the API, with the token as a fallback.
  */
 export interface EnvAuthConfig {
     /**

--- a/packages/cli/src/publish.ts
+++ b/packages/cli/src/publish.ts
@@ -5,7 +5,7 @@ import * as api from '@gitbook/api';
 
 import { buildScriptFromManifest } from './build';
 import { resolveFile } from './manifest';
-import { assertCanPublishIntegrations, getAPIClient } from './remote';
+import { getAPIClient } from './remote';
 
 /**
  * Publish the integration to GitBook.
@@ -15,12 +15,10 @@ export async function publishIntegration(
     specFilePath: string,
     updates: Partial<api.RequestPublishIntegration> = {},
 ): Promise<void> {
-    assertCanPublishIntegrations();
-
     // Build the script
     const { script, manifest } = await buildScriptFromManifest(specFilePath);
 
-    const api = await getAPIClient(true, { personalTokenOnly: true });
+    const api = await getAPIClient(true);
 
     if (typeof manifest.target === 'string') {
         console.log(
@@ -65,9 +63,7 @@ export async function publishIntegration(
  * Delete an integration
  */
 export async function unpublishIntegration(name: string): Promise<void> {
-    assertCanPublishIntegrations();
-
-    const api = await getAPIClient(true, { personalTokenOnly: true });
+    const api = await getAPIClient(true);
     await api.integrations.unpublishIntegration(name);
 
     console.log(`👌 Integration "${name}" has been deleted`);

--- a/packages/cli/src/remote.ts
+++ b/packages/cli/src/remote.ts
@@ -1,108 +1,172 @@
-import { GitBookAPI } from '@gitbook/api';
+import { GitBookAPI, type GitBookAPIServiceBinding } from "@gitbook/api";
 
-import { version } from '../package.json';
-import { clearAuthConfig, getAuthConfig, getStoredEnvConfig, saveAuthConfig } from './config';
-import { DEFAULT_ENV, getEnvironment } from './environments';
-import { authenticateWithBrowser, refreshOAuthSessionIfNeeded } from './oauth';
-import { type OutputOptions, printResult } from './output';
+import { version } from "../package.json";
+import {
+  clearAuthConfig,
+  getAuthConfig,
+  getStoredEnvConfig,
+  saveAuthConfig,
+} from "./config";
+import { DEFAULT_ENV, getEnvironment } from "./environments";
+import { authenticateWithBrowser, refreshOAuthSessionIfNeeded } from "./oauth";
+import { type OutputOptions, printResult } from "./output";
 
 const USER_AGENT = `GitBook-CLI/${version}`;
 
-interface GetAPIClientOptions {
-    /**
-     * Only use a personal API token, never the OAuth session. Used by operations that aren't
-     * available to OAuth tokens (e.g. publishing integrations).
-     */
-    personalTokenOnly?: boolean;
-}
+/**
+ * Extracted from the API's 403 error message when the token is missing OAuth scopes, e.g. "This
+ * method cannot be accessed with this authentication (missing OAuth scopes: integration:publish)".
+ */
+const MISSING_SCOPES_REGEX = /missing OAuth scopes:\s*([^)]+)/i;
 
 /**
  * Get an authenticated API client.
  *
  * When the user has a browser (OAuth) session it is used (and its access token refreshed as
- * needed); a personal API token is used otherwise, or when `personalTokenOnly` is set.
+ * needed); a personal API token is used otherwise.
  */
 export async function getAPIClient(
-    requireAuth: boolean = true,
-    options: GetAPIClientOptions = {},
+  requireAuth: boolean = true,
 ): Promise<GitBookAPI> {
-    const { endpoint, token } = await resolveAuth(options.personalTokenOnly ?? false);
-    if (!token && requireAuth) {
-        throw new Error(
-            `You must be authenticated before you can run this command.\n  Run "${getLoginCommand()}" to sign in with your browser, or "${getAuthCommand()}" to use an API token.`,
-        );
-    }
+  const { endpoint, token, oauth } = await resolveAuth();
+  if (!token && requireAuth) {
+    throw new Error(
+      `You must be authenticated before you can run this command.\n  Run "${getLoginCommand()}" to sign in with your browser, or "${getAuthCommand()}" to use an API token.`,
+    );
+  }
 
-    return new GitBookAPI({
-        userAgent: USER_AGENT,
-        endpoint,
-        authToken: token,
-    });
+  return new GitBookAPI({
+    userAgent: USER_AGENT,
+    endpoint,
+    authToken: token,
+    serviceBinding: oauth ? createScopeAwareServiceBinding() : undefined,
+  });
 }
 
 /**
- * Resolve the access token to use, preferring the OAuth session (refreshing and persisting it
- * when needed) and falling back to a personal API token.
+ * Resolve the credentials to use, preferring the OAuth session (refreshing and persisting it
+ * when needed) and falling back to a personal API token. `oauth` reports which one was picked.
  */
-async function resolveAuth(
-    personalTokenOnly: boolean,
-): Promise<{ endpoint: string; token?: string }> {
-    const authConfig = getAuthConfig();
+async function resolveAuth(): Promise<{
+  endpoint: string;
+  token?: string;
+  oauth: boolean;
+}> {
+  const authConfig = getAuthConfig();
 
-    if (!personalTokenOnly && authConfig.oauth) {
-        const refreshed = await refreshOAuthSessionIfNeeded(authConfig.oauth);
-        if (refreshed) {
-            // Persist a rotated access/refresh token so later commands reuse it.
-            if (refreshed.accessToken !== authConfig.oauth.accessToken) {
-                saveAuthConfig({ ...authConfig, oauth: refreshed });
-            }
-            return { endpoint: authConfig.endpoint, token: refreshed.accessToken };
-        }
-
-        // The OAuth session expired and couldn't be refreshed. Fall back to a personal token
-        // if one is configured, otherwise prompt the user to sign in again.
-        if (authConfig.token) {
-            return { endpoint: authConfig.endpoint, token: authConfig.token };
-        }
-        throw new Error(`Your session has expired. Run "${getLoginCommand()}" to sign in again.`);
+  if (authConfig.oauth) {
+    const refreshed = await refreshOAuthSessionIfNeeded(authConfig.oauth);
+    if (refreshed) {
+      // Persist a rotated access/refresh token so later commands reuse it.
+      if (refreshed.accessToken !== authConfig.oauth.accessToken) {
+        saveAuthConfig({ ...authConfig, oauth: refreshed });
+      }
+      return {
+        endpoint: authConfig.endpoint,
+        token: refreshed.accessToken,
+        oauth: true,
+      };
     }
 
-    return { endpoint: authConfig.endpoint, token: authConfig.token };
+    // The OAuth session expired and couldn't be refreshed. Fall back to a personal token
+    // if one is configured, otherwise prompt the user to sign in again.
+    if (authConfig.token) {
+      return {
+        endpoint: authConfig.endpoint,
+        token: authConfig.token,
+        oauth: false,
+      };
+    }
+    throw new Error(
+      `Your session has expired. Run "${getLoginCommand()}" to sign in again.`,
+    );
+  }
+
+  return {
+    endpoint: authConfig.endpoint,
+    token: authConfig.token,
+    oauth: false,
+  };
+}
+
+/**
+ * Fetch layer used for OAuth sessions, turning a "missing OAuth scopes" 403 into actionable
+ * guidance before the API client reports it as a generic error.
+ */
+function createScopeAwareServiceBinding(): GitBookAPIServiceBinding {
+  return {
+    fetch: async (input, init) => {
+      const response = await fetch(input, init);
+      if (response.status !== 403) {
+        return response;
+      }
+
+      // Read from a clone so the API client can still parse the original body.
+      const missingScopes = await readMissingScopes(response.clone());
+      if (!missingScopes) {
+        return response;
+      }
+
+      throw new Error(
+        `Your session does not include the permissions needed to run this command (missing: ${missingScopes}).\n` +
+          `  Run "${getLoginCommand()}" again and grant them to continue.`,
+      );
+    },
+  };
+}
+
+/**
+ * Read the scopes the API reports as missing from a 403 response, or `undefined` when the
+ * response isn't a missing-scopes error.
+ */
+async function readMissingScopes(
+  response: Response,
+): Promise<string | undefined> {
+  try {
+    const body = (await response.json()) as { error?: { message?: string } };
+    return (
+      body?.error?.message?.match(MISSING_SCOPES_REGEX)?.[1]?.trim() ||
+      undefined
+    );
+  } catch {
+    // Not a JSON error body, so let the API client report the raw failure.
+    return undefined;
+  }
 }
 
 /**
  * Authenticate with an API token, preserving any existing browser (OAuth) session.
  */
 export async function authenticate({
+  endpoint,
+  authToken,
+}: {
+  /**
+   * API endpoint to authenticate to.
+   */
+  endpoint: string;
+  /**
+   * API token to authenticate with.
+   */
+  authToken: string;
+}): Promise<void> {
+  console.log(`Authenticating with ${endpoint}...`);
+
+  const api = new GitBookAPI({
+    userAgent: USER_AGENT,
     endpoint,
     authToken,
-}: {
-    /**
-     * API endpoint to authenticate to.
-     */
-    endpoint: string;
-    /**
-     * API token to authenticate with.
-     */
-    authToken: string;
-}): Promise<void> {
-    console.log(`Authenticating with ${endpoint}...`);
+  });
 
-    const api = new GitBookAPI({
-        userAgent: USER_AGENT,
-        endpoint,
-        authToken,
-    });
+  const { data: user } = await api.user.getAuthenticatedUser();
 
-    const { data: user } = await api.user.getAuthenticatedUser();
+  saveAuthConfig({
+    ...getStoredEnvConfig(),
+    endpoint,
+    token: authToken,
+  });
 
-    saveAuthConfig({
-        ...getStoredEnvConfig(),
-        endpoint,
-        token: authToken,
-    });
-
-    console.log(`You are now authenticated as ${user.displayName}.`);
+  console.log(`You are now authenticated as ${user.displayName}.`);
 }
 
 /**
@@ -110,110 +174,97 @@ export async function authenticate({
  * existing personal API token.
  */
 export async function login({ endpoint }: { endpoint: string }): Promise<void> {
-    console.log(`Opening your browser to sign in with ${endpoint}...`);
+  console.log(`Opening your browser to sign in with ${endpoint}...`);
 
-    const oauth = await authenticateWithBrowser({
-        endpoint,
-        onAuthorizationURL: (url) => {
-            console.log(`\nIf your browser did not open, visit this URL to continue:\n  ${url}\n`);
-        },
-    });
+  const oauth = await authenticateWithBrowser({
+    endpoint,
+    onAuthorizationURL: (url) => {
+      console.log(
+        `\nIf your browser did not open, visit this URL to continue:\n  ${url}\n`,
+      );
+    },
+  });
 
-    const api = new GitBookAPI({
-        userAgent: USER_AGENT,
-        endpoint,
-        authToken: oauth.accessToken,
-    });
+  const api = new GitBookAPI({
+    userAgent: USER_AGENT,
+    endpoint,
+    authToken: oauth.accessToken,
+  });
 
-    const { data: user } = await api.user.getAuthenticatedUser();
+  const { data: user } = await api.user.getAuthenticatedUser();
 
-    saveAuthConfig({
-        ...getStoredEnvConfig(),
-        endpoint,
-        oauth,
-    });
+  saveAuthConfig({
+    ...getStoredEnvConfig(),
+    endpoint,
+    oauth,
+  });
 
-    console.log(`\nYou are now authenticated as ${user.displayName}.`);
+  console.log(`\nYou are now authenticated as ${user.displayName}.`);
 }
 
 /**
  * Remove the stored authentication (token and OAuth session) for the current environment.
  */
 export async function logout(): Promise<void> {
-    clearAuthConfig();
-    console.log('You have been logged out.');
+  clearAuthConfig();
+  console.log("You have been logged out.");
 }
 
 /**
  * Print authentication infos
  */
 export async function whoami(options: OutputOptions = {}): Promise<void> {
-    const env = getEnvironment();
-    const authConfig = getAuthConfig();
-    const api = await getAPIClient(false);
-    // Only the explicit --json/--yaml flags switch to machine output; unlike the
-    // generated commands we don't auto-switch when piped, so the human form (and
-    // the not-authenticated guidance) stays the interactive default.
-    const machine = options.json || options.yaml;
+  const env = getEnvironment();
+  const authConfig = getAuthConfig();
+  const api = await getAPIClient(false);
+  // Only the explicit --json/--yaml flags switch to machine output; unlike the
+  // generated commands we don't auto-switch when piped, so the human form (and
+  // the not-authenticated guidance) stays the interactive default.
+  const machine = options.json || options.yaml;
 
-    if (!api.authToken) {
-        if (machine) {
-            printResult({ authenticated: false }, options);
-        } else {
-            console.log(
-                `No authentication configured. Run "${getLoginCommand()}" to sign in with your browser, or "${getAuthCommand()}" to use an API token.`,
-            );
-        }
-        return;
-    }
-
-    const { data: user } = await api.user.getAuthenticatedUser();
-
+  if (!api.authToken) {
     if (machine) {
-        // Emit the user object itself so scripts can read e.g. `--json | jq -r .id`
-        // for their own user ID (the reason this command needed machine output).
-        printResult(user, options);
-        return;
+      printResult({ authenticated: false }, options);
+    } else {
+      console.log(
+        `No authentication configured. Run "${getLoginCommand()}" to sign in with your browser, or "${getAuthCommand()}" to use an API token.`,
+      );
     }
+    return;
+  }
 
-    console.log(`Authenticated as ${user.displayName}`);
-    console.log(`ID: ${user.id}`);
-    console.log(`Email: ${user.email}`);
-    console.log(`API: ${api.endpoint}`);
-    console.log(`Method: ${authConfig.oauth ? 'browser (OAuth)' : 'API token'}`);
-    if (authConfig.oauth && authConfig.token) {
-        console.log('A personal API token is also configured (used for publishing integrations).');
-    }
-    if (env !== DEFAULT_ENV) {
-        console.log(`Environment: ${env}`);
-    }
-}
+  const { data: user } = await api.user.getAuthenticatedUser();
 
-/**
- * Throw a helpful error if the current session can't publish integrations.
- *
- * Publishing/unpublishing integrations is not an OAuth-exposed API operation, so a browser
- * (OAuth) session can't perform it — a personal API token is required.
- */
-export function assertCanPublishIntegrations(): void {
-    const authConfig = getAuthConfig();
-    if (!authConfig.token && authConfig.oauth) {
-        throw new Error(
-            'Publishing integrations requires a personal API token, but you are signed in through the browser (OAuth).\n' +
-                '  Create a token at https://app.gitbook.com/account/developer and run:\n' +
-                `    ${getAuthCommand()}`,
-        );
-    }
+  if (machine) {
+    // Emit the user object itself so scripts can read e.g. `--json | jq -r .id`
+    // for their own user ID (the reason this command needed machine output).
+    printResult(user, options);
+    return;
+  }
+
+  console.log(`Authenticated as ${user.displayName}`);
+  console.log(`ID: ${user.id}`);
+  console.log(`Email: ${user.email}`);
+  console.log(`API: ${api.endpoint}`);
+  console.log(`Method: ${authConfig.oauth ? "browser (OAuth)" : "API token"}`);
+  if (authConfig.oauth && authConfig.token) {
+    console.log(
+      "A personal API token is also configured (used as a fallback).",
+    );
+  }
+  if (env !== DEFAULT_ENV) {
+    console.log(`Environment: ${env}`);
+  }
 }
 
 function getAuthCommand() {
-    const env = getEnvironment();
-    return env === DEFAULT_ENV
-        ? 'gitbook auth --token <token>'
-        : `gitbook auth --token <token> --env ${env}`;
+  const env = getEnvironment();
+  return env === DEFAULT_ENV
+    ? "gitbook auth --token <token>"
+    : `gitbook auth --token <token> --env ${env}`;
 }
 
 function getLoginCommand() {
-    const env = getEnvironment();
-    return env === DEFAULT_ENV ? 'gitbook login' : `gitbook login --env ${env}`;
+  const env = getEnvironment();
+  return env === DEFAULT_ENV ? "gitbook login" : `gitbook login --env ${env}`;
 }

--- a/packages/cli/src/remote.ts
+++ b/packages/cli/src/remote.ts
@@ -1,15 +1,10 @@
-import { GitBookAPI, type GitBookAPIServiceBinding } from "@gitbook/api";
+import { GitBookAPI, type GitBookAPIServiceBinding } from '@gitbook/api';
 
-import { version } from "../package.json";
-import {
-  clearAuthConfig,
-  getAuthConfig,
-  getStoredEnvConfig,
-  saveAuthConfig,
-} from "./config";
-import { DEFAULT_ENV, getEnvironment } from "./environments";
-import { authenticateWithBrowser, refreshOAuthSessionIfNeeded } from "./oauth";
-import { type OutputOptions, printResult } from "./output";
+import { version } from '../package.json';
+import { clearAuthConfig, getAuthConfig, getStoredEnvConfig, saveAuthConfig } from './config';
+import { DEFAULT_ENV, getEnvironment } from './environments';
+import { authenticateWithBrowser, refreshOAuthSessionIfNeeded } from './oauth';
+import { type OutputOptions, printResult } from './output';
 
 const USER_AGENT = `GitBook-CLI/${version}`;
 
@@ -25,22 +20,20 @@ const MISSING_SCOPES_REGEX = /missing OAuth scopes:\s*([^)]+)/i;
  * When the user has a browser (OAuth) session it is used (and its access token refreshed as
  * needed); a personal API token is used otherwise.
  */
-export async function getAPIClient(
-  requireAuth: boolean = true,
-): Promise<GitBookAPI> {
-  const { endpoint, token, oauth } = await resolveAuth();
-  if (!token && requireAuth) {
-    throw new Error(
-      `You must be authenticated before you can run this command.\n  Run "${getLoginCommand()}" to sign in with your browser, or "${getAuthCommand()}" to use an API token.`,
-    );
-  }
+export async function getAPIClient(requireAuth: boolean = true): Promise<GitBookAPI> {
+    const { endpoint, token, oauth } = await resolveAuth();
+    if (!token && requireAuth) {
+        throw new Error(
+            `You must be authenticated before you can run this command.\n  Run "${getLoginCommand()}" to sign in with your browser, or "${getAuthCommand()}" to use an API token.`,
+        );
+    }
 
-  return new GitBookAPI({
-    userAgent: USER_AGENT,
-    endpoint,
-    authToken: token,
-    serviceBinding: oauth ? createScopeAwareServiceBinding() : undefined,
-  });
+    return new GitBookAPI({
+        userAgent: USER_AGENT,
+        endpoint,
+        authToken: token,
+        serviceBinding: oauth ? createScopeAwareServiceBinding() : undefined,
+    });
 }
 
 /**
@@ -48,45 +41,43 @@ export async function getAPIClient(
  * when needed) and falling back to a personal API token. `oauth` reports which one was picked.
  */
 async function resolveAuth(): Promise<{
-  endpoint: string;
-  token?: string;
-  oauth: boolean;
+    endpoint: string;
+    token?: string;
+    oauth: boolean;
 }> {
-  const authConfig = getAuthConfig();
+    const authConfig = getAuthConfig();
 
-  if (authConfig.oauth) {
-    const refreshed = await refreshOAuthSessionIfNeeded(authConfig.oauth);
-    if (refreshed) {
-      // Persist a rotated access/refresh token so later commands reuse it.
-      if (refreshed.accessToken !== authConfig.oauth.accessToken) {
-        saveAuthConfig({ ...authConfig, oauth: refreshed });
-      }
-      return {
-        endpoint: authConfig.endpoint,
-        token: refreshed.accessToken,
-        oauth: true,
-      };
+    if (authConfig.oauth) {
+        const refreshed = await refreshOAuthSessionIfNeeded(authConfig.oauth);
+        if (refreshed) {
+            // Persist a rotated access/refresh token so later commands reuse it.
+            if (refreshed.accessToken !== authConfig.oauth.accessToken) {
+                saveAuthConfig({ ...authConfig, oauth: refreshed });
+            }
+            return {
+                endpoint: authConfig.endpoint,
+                token: refreshed.accessToken,
+                oauth: true,
+            };
+        }
+
+        // The OAuth session expired and couldn't be refreshed. Fall back to a personal token
+        // if one is configured, otherwise prompt the user to sign in again.
+        if (authConfig.token) {
+            return {
+                endpoint: authConfig.endpoint,
+                token: authConfig.token,
+                oauth: false,
+            };
+        }
+        throw new Error(`Your session has expired. Run "${getLoginCommand()}" to sign in again.`);
     }
 
-    // The OAuth session expired and couldn't be refreshed. Fall back to a personal token
-    // if one is configured, otherwise prompt the user to sign in again.
-    if (authConfig.token) {
-      return {
+    return {
         endpoint: authConfig.endpoint,
         token: authConfig.token,
         oauth: false,
-      };
-    }
-    throw new Error(
-      `Your session has expired. Run "${getLoginCommand()}" to sign in again.`,
-    );
-  }
-
-  return {
-    endpoint: authConfig.endpoint,
-    token: authConfig.token,
-    oauth: false,
-  };
+    };
 }
 
 /**
@@ -94,79 +85,74 @@ async function resolveAuth(): Promise<{
  * guidance before the API client reports it as a generic error.
  */
 function createScopeAwareServiceBinding(): GitBookAPIServiceBinding {
-  return {
-    fetch: async (input, init) => {
-      const response = await fetch(input, init);
-      if (response.status !== 403) {
-        return response;
-      }
+    return {
+        fetch: async (input, init) => {
+            const response = await fetch(input, init);
+            if (response.status !== 403) {
+                return response;
+            }
 
-      // Read from a clone so the API client can still parse the original body.
-      const missingScopes = await readMissingScopes(response.clone());
-      if (!missingScopes) {
-        return response;
-      }
+            // Read from a clone so the API client can still parse the original body.
+            const missingScopes = await readMissingScopes(response.clone());
+            if (!missingScopes) {
+                return response;
+            }
 
-      throw new Error(
-        `Your session does not include the permissions needed to run this command (missing: ${missingScopes}).\n` +
-          `  Run "${getLoginCommand()}" again and grant them to continue.`,
-      );
-    },
-  };
+            throw new Error(
+                `Your session does not include the permissions needed to run this command (missing: ${missingScopes}).\n` +
+                    `  Run "${getLoginCommand()}" again and grant them to continue.`,
+            );
+        },
+    };
 }
 
 /**
  * Read the scopes the API reports as missing from a 403 response, or `undefined` when the
  * response isn't a missing-scopes error.
  */
-async function readMissingScopes(
-  response: Response,
-): Promise<string | undefined> {
-  try {
-    const body = (await response.json()) as { error?: { message?: string } };
-    return (
-      body?.error?.message?.match(MISSING_SCOPES_REGEX)?.[1]?.trim() ||
-      undefined
-    );
-  } catch {
-    // Not a JSON error body, so let the API client report the raw failure.
-    return undefined;
-  }
+async function readMissingScopes(response: Response): Promise<string | undefined> {
+    try {
+        const body = (await response.json()) as { error?: { message?: string } };
+        return body?.error?.message?.match(MISSING_SCOPES_REGEX)?.[1]?.trim() || undefined;
+    } catch {
+        // Not a JSON error body, so let the API client report the raw failure.
+        return undefined;
+    }
 }
 
 /**
  * Authenticate with an API token, preserving any existing browser (OAuth) session.
  */
 export async function authenticate({
-  endpoint,
-  authToken,
-}: {
-  /**
-   * API endpoint to authenticate to.
-   */
-  endpoint: string;
-  /**
-   * API token to authenticate with.
-   */
-  authToken: string;
-}): Promise<void> {
-  console.log(`Authenticating with ${endpoint}...`);
-
-  const api = new GitBookAPI({
-    userAgent: USER_AGENT,
     endpoint,
     authToken,
-  });
+}: {
+    /**
+     * API endpoint to authenticate to.
+     */
+    endpoint: string;
+    /**
+     * API token to authenticate with.
+     */
+    authToken: string;
+}): Promise<void> {
+    console.log(`Authenticating with ${endpoint}...`);
 
-  const { data: user } = await api.user.getAuthenticatedUser();
+    const api = new GitBookAPI({
+        userAgent: USER_AGENT,
+        endpoint,
+        authToken,
+    });
 
-  saveAuthConfig({
-    ...getStoredEnvConfig(),
-    endpoint,
-    token: authToken,
-  });
+    const { data: user } = await api.user.getAuthenticatedUser();
 
-  console.log(`You are now authenticated as ${user.displayName}.`);
+    saveAuthConfig({
+        ...getStoredEnvConfig(),
+        endpoint,
+        token: authToken,
+    });
+
+    console.log(`You are now authenticated as ${user.displayName}.`);
 }
 
 /**
@@ -174,97 +160,93 @@ export async function authenticate({
  * existing personal API token.
  */
 export async function login({ endpoint }: { endpoint: string }): Promise<void> {
-  console.log(`Opening your browser to sign in with ${endpoint}...`);
+    console.log(`Opening your browser to sign in with ${endpoint}...`);
 
-  const oauth = await authenticateWithBrowser({
-    endpoint,
-    onAuthorizationURL: (url) => {
-      console.log(
-        `\nIf your browser did not open, visit this URL to continue:\n  ${url}\n`,
-      );
-    },
-  });
+    const oauth = await authenticateWithBrowser({
+        endpoint,
+        onAuthorizationURL: (url) => {
+            console.log(`\nIf your browser did not open, visit this URL to continue:\n  ${url}\n`);
+        },
+    });
 
-  const api = new GitBookAPI({
-    userAgent: USER_AGENT,
-    endpoint,
-    authToken: oauth.accessToken,
-  });
+    const api = new GitBookAPI({
+        userAgent: USER_AGENT,
+        endpoint,
+        authToken: oauth.accessToken,
+    });
 
-  const { data: user } = await api.user.getAuthenticatedUser();
+    const { data: user } = await api.user.getAuthenticatedUser();
 
-  saveAuthConfig({
-    ...getStoredEnvConfig(),
-    endpoint,
-    oauth,
-  });
+    saveAuthConfig({
+        ...getStoredEnvConfig(),
+        endpoint,
+        oauth,
+    });
 
-  console.log(`\nYou are now authenticated as ${user.displayName}.`);
+    console.log(`\nYou are now authenticated as ${user.displayName}.`);
 }
 
 /**
  * Remove the stored authentication (token and OAuth session) for the current environment.
  */
 export async function logout(): Promise<void> {
-  clearAuthConfig();
-  console.log("You have been logged out.");
+    clearAuthConfig();
+    console.log('You have been logged out.');
 }
 
 /**
  * Print authentication infos
  */
 export async function whoami(options: OutputOptions = {}): Promise<void> {
-  const env = getEnvironment();
-  const authConfig = getAuthConfig();
-  const api = await getAPIClient(false);
-  // Only the explicit --json/--yaml flags switch to machine output; unlike the
-  // generated commands we don't auto-switch when piped, so the human form (and
-  // the not-authenticated guidance) stays the interactive default.
-  const machine = options.json || options.yaml;
+    const env = getEnvironment();
+    const authConfig = getAuthConfig();
+    const api = await getAPIClient(false);
+    // Only the explicit --json/--yaml flags switch to machine output; unlike the
+    // generated commands we don't auto-switch when piped, so the human form (and
+    // the not-authenticated guidance) stays the interactive default.
+    const machine = options.json || options.yaml;
 
-  if (!api.authToken) {
-    if (machine) {
-      printResult({ authenticated: false }, options);
-    } else {
-      console.log(
-        `No authentication configured. Run "${getLoginCommand()}" to sign in with your browser, or "${getAuthCommand()}" to use an API token.`,
-      );
+    if (!api.authToken) {
+        if (machine) {
+            printResult({ authenticated: false }, options);
+        } else {
+            console.log(
+                `No authentication configured. Run "${getLoginCommand()}" to sign in with your browser, or "${getAuthCommand()}" to use an API token.`,
+            );
+        }
+        return;
     }
-    return;
-  }
 
-  const { data: user } = await api.user.getAuthenticatedUser();
+    const { data: user } = await api.user.getAuthenticatedUser();
 
-  if (machine) {
-    // Emit the user object itself so scripts can read e.g. `--json | jq -r .id`
-    // for their own user ID (the reason this command needed machine output).
-    printResult(user, options);
-    return;
-  }
+    if (machine) {
+        // Emit the user object itself so scripts can read e.g. `--json | jq -r .id`
+        // for their own user ID (the reason this command needed machine output).
+        printResult(user, options);
+        return;
+    }
 
-  console.log(`Authenticated as ${user.displayName}`);
-  console.log(`ID: ${user.id}`);
-  console.log(`Email: ${user.email}`);
-  console.log(`API: ${api.endpoint}`);
-  console.log(`Method: ${authConfig.oauth ? "browser (OAuth)" : "API token"}`);
-  if (authConfig.oauth && authConfig.token) {
-    console.log(
-      "A personal API token is also configured (used as a fallback).",
-    );
-  }
-  if (env !== DEFAULT_ENV) {
-    console.log(`Environment: ${env}`);
-  }
+    console.log(`Authenticated as ${user.displayName}`);
+    console.log(`ID: ${user.id}`);
+    console.log(`Email: ${user.email}`);
+    console.log(`API: ${api.endpoint}`);
+    console.log(`Method: ${authConfig.oauth ? 'browser (OAuth)' : 'API token'}`);
+    if (authConfig.oauth && authConfig.token) {
+        console.log('A personal API token is also configured (used as a fallback).');
+    }
+    if (env !== DEFAULT_ENV) {
+        console.log(`Environment: ${env}`);
+    }
 }
 
 function getAuthCommand() {
-  const env = getEnvironment();
-  return env === DEFAULT_ENV
-    ? "gitbook auth --token <token>"
-    : `gitbook auth --token <token> --env ${env}`;
+    const env = getEnvironment();
+    return env === DEFAULT_ENV
+        ? 'gitbook auth --token <token>'
+        : `gitbook auth --token <token> --env ${env}`;
 }
 
 function getLoginCommand() {
-  const env = getEnvironment();
-  return env === DEFAULT_ENV ? "gitbook login" : `gitbook login --env ${env}`;
+    const env = getEnvironment();
+    return env === DEFAULT_ENV ? 'gitbook login' : `gitbook login --env ${env}`;
 }


### PR DESCRIPTION
This PR aims to update the CLI to use OAuth for integrations, so `gitbook login` also covers the integrations commands now that the API exposes integration endpoints to OAuth tokens (in https://github.com/GitbookIO/gitbook-x/pull/25029).