### PR TITLE
Bump API to 0.198.0

### DIFF
--- a/.changeset/bump-api-0-198.md
+++ b/.changeset/bump-api-0-198.md
@@ -1,0 +1,6 @@
+---
+'@gitbook/api': minor
+'@gitbook/cli': patch
+---
+
+Bump API to 0.198.0 and regenerate CLI commands


### PR DESCRIPTION
## Summary

- release `@gitbook/api` 0.198.0 with a minor changeset
- republish `@gitbook/cli` with a patch bump so its commands are regenerated from the latest API spec

## Validation

- `BASE_SHA=$(git rev-parse origin/main) ./scripts/changeset-guard.sh`
- `git diff --check origin/main...HEAD`