### PR TITLE
Add report feedback command to GitBook CLI

### DIFF
--- a/.changeset/cyan-eagles-attack.md
+++ b/.changeset/cyan-eagles-attack.md
@@ -1,0 +1,5 @@
+---
+"@gitbook/cli": minor
+---
+
+Add report feedback command to GitBook CLI

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -22,15 +22,19 @@ import * as os from 'os';
 import * as path from 'path';
 
 import checkNodeVersion from 'check-node-version';
+import dedent from 'dedent-js';
 import { program } from 'commander';
 import prompts from 'prompts';
 
 import { GITBOOK_DEFAULT_ENDPOINT } from '@gitbook/api';
 
 import packageJSON from '../package.json';
+import { formatCommandFailure } from './errors';
+import { reportFeedback, resolveFeedbackInput } from './feedback';
 import { authenticate, login, logout, whoami } from './remote';
 import { withEnvironment } from './environments';
 import { registerGeneratedCommands, COMPLETIONS } from './generated-commands';
+import { printResult } from './output';
 import { registerCustomCommands } from './api-commands';
 import { installCommandTreeHelp } from './help-tree';
 
@@ -98,6 +102,100 @@ program
     .action(async (options) => {
         return withEnvironment(options.env, async () => {
             await whoami({ json: options.json, yaml: options.yaml });
+        });
+    });
+
+program
+    .command('feedback')
+    .description(
+        'report friction with the CLI, or suggest an improvement — agents: use it when a command confuses, blocks or fails you, or nothing can do what you need',
+    )
+    .option(
+        '--category <category>',
+        'usability | reliability | documentation | efficiency | interoperability | could-not-accomplish',
+    )
+    .option('--summary <summary>', 'one short sentence naming the problem (max 256 chars)')
+    .option(
+        '--command <command>',
+        'the command it was about, without arguments; omit when nothing could do what you needed',
+    )
+    .option('--flag <name...>', 'flag names passed to that command (names only, never values)')
+    .option('--severity <severity>', 'low | medium | high')
+    .option('--detail <detail>', 'what happened and how you ran into it')
+    .option('--goal <goal>', 'what you were trying to accomplish')
+    .option('--workaround <workaround>', 'how you worked around it, if you did')
+    .option('--model <model>', 'the model reporting, when an agent is running the CLI')
+    .option('--on-demand', 'the user explicitly asked for this to be reported')
+    .option('--body <json>', 'the whole report as a JSON object, instead of the flags above')
+    .option('--json', 'Output as JSON (machine-readable)')
+    .option('--yaml', 'Output as YAML (machine-readable)')
+    .option('--pretty', 'Output in human-readable form (default when attached to a terminal)')
+    .option('--full', 'Show all fields (disable compact summaries in pretty mode)')
+    .option('--env <env>', 'environment to report to')
+    .addHelpText(
+        'after',
+        dedent(`
+
+        Report as soon as you hit the problem, while you still remember what you were trying
+        to do, then carry on. Reporting is cheap and changes nothing about your current task.
+
+        Worth reporting:
+          - a command, flag or its help text that led you to the wrong choice
+          - a command that failed, or produced output you could not use
+          - a task that took far more commands than it should have
+          - something you needed that no command could do (omit --command: that records the
+            missing capability rather than blaming one command)
+          - an improvement worth making, even when nothing went wrong
+
+        Suggestions have no category of their own yet, so pick the one the improvement is
+        about: efficiency for fewer commands or less output, usability for a clearer name or
+        flag, interoperability for composing better, could-not-accomplish for something
+        missing entirely.
+
+        Categories:
+          usability             hard to understand or use correctly
+          reliability           failed unexpectedly or returned something unusable
+          documentation         its own help or docs were missing, unclear or misleading
+          efficiency            took more commands, steps or output than it should have
+          interoperability      did not compose with other commands or formats
+          could-not-accomplish  nothing available could do what was needed
+
+        Use --severity high only when you could not finish the task at all.
+
+        Never put flag values, file contents, credentials or anything identifying a person
+        into a report. Describe the problem, not the data. --flag takes names only.
+
+        Agents can pass the whole report as one object instead of flags:
+
+          gitbook feedback --body '{
+            "category": "documentation",
+            "severity": "medium",
+            "summary": "publish --draft is not documented",
+            "command": "gitbook integration publish",
+            "flags": ["--draft"],
+            "goal": "Publish a draft integration"
+          }'
+        `),
+    )
+    .action(async (options) => {
+        return withEnvironment(options.env, async () => {
+            const input = resolveFeedbackInput(
+                options.body ? JSON.parse(options.body) : undefined,
+                {
+                    category: options.category,
+                    summary: options.summary,
+                    command: options.command,
+                    flags: options.flag,
+                    severity: options.severity,
+                    detail: options.detail,
+                    goal: options.goal,
+                    workaround: options.workaround,
+                    model: options.model,
+                    onDemand: options.onDemand,
+                },
+            );
+
+            printResult(await reportFeedback(input), options);
         });
     });
 
@@ -195,7 +293,7 @@ checkNodeVersion({ node: '>= 18' }, (error, result) => {
             process.exit(0);
         },
         (error) => {
-            console.error(error.message);
+            console.error(formatCommandFailure(error, program.args));
             process.exit(1);
         },
     );

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,0 +1,46 @@
+/**
+ * Failure reporting shared by every command: whether a failure is the caller's to fix, and
+ * how it is rendered.
+ *
+ * Deliberately dependency-free so any module can tag an error without pulling in a command.
+ */
+/**
+ * Mark an error as something the person running the CLI can fix themselves.
+ *
+ * Those failures are not friction with a command, so they must not invite a feedback
+ * report: doing so would bury the real reports under noise.
+ */
+export function markUserActionable<E extends Error>(error: E): E {
+    (error as E & { userActionable?: boolean }).userActionable = true;
+    return error;
+}
+
+/**
+ * Render a command failure, inviting a feedback report when the failure looks like a
+ * problem with the command rather than with how it was called.
+ *
+ * This is where an agent is most likely to act on the invitation, having just hit the
+ * problem; the command's own help is only read by someone already looking for it.
+ */
+export function formatCommandFailure(error: unknown, argv: readonly string[]): string {
+    const message = error instanceof Error ? error.message : String(error);
+    return shouldInviteReport(error, argv)
+        ? `${message}\n\nIf this looks like a problem with the command rather than your input, report it with \`gitbook feedback\` and carry on.`
+        : message;
+}
+
+function shouldInviteReport(error: unknown, argv: readonly string[]): boolean {
+    // Never ask an agent to report that reporting failed.
+    if (argv[0] === 'feedback') {
+        return false;
+    }
+
+    const candidate = error as { userActionable?: boolean; code?: unknown } | null;
+    if (candidate?.userActionable) {
+        return false;
+    }
+
+    // Commander raises usage errors (unknown command, missing argument) for mistakes in the
+    // invocation, which the caller fixes rather than reports.
+    return !(typeof candidate?.code === 'string' && candidate.code.startsWith('commander.'));
+}

--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -1,0 +1,215 @@
+import { GitBookAPI } from '@gitbook/api';
+
+import { config, getAuthConfig } from './config';
+import { getEnvironment } from './environments';
+import { USER_AGENT } from './remote';
+
+/**
+ * Published docs site collecting the feedback, per API endpoint.
+ *
+ * The site is chosen from the endpoint rather than a flag so a CLI pointed elsewhere can
+ * never report into the production docs site. An endpoint that is not listed collects
+ * nothing.
+ */
+const DOCS_SITE_URL_BY_API_HOST: Record<string, string> = {
+    'api.gitbook.com': 'https://gitbook.com/docs',
+};
+
+/**
+ * Refresh a cached token this long before it expires, so a submission started just under the
+ * wire does not race the expiry.
+ */
+const EXPIRY_MARGIN_MS = 5 * 60 * 1000;
+
+export interface FeedbackInput {
+    category: string;
+    summary: string;
+    command?: string;
+    flags?: string[];
+    severity?: string;
+    detail?: string;
+    goal?: string;
+    workaround?: string;
+    model?: string;
+    onDemand?: boolean;
+}
+
+/**
+ * The recorded submission, as returned by the API.
+ */
+export interface FeedbackResult {
+    id: string;
+    result: string;
+}
+
+/**
+ * Report feedback with a CLI command to GitBook's docs site.
+ */
+export async function reportFeedback(input: FeedbackInput): Promise<FeedbackResult> {
+    const { endpoint } = getAuthConfig();
+    const siteUrl = getDocsSiteURL(endpoint);
+    if (!siteUrl) {
+        throw new Error(
+            `Feedback is not collected for the API endpoint "${endpoint}", so there is nowhere to send this report.`,
+        );
+    }
+
+    const { token, organization, site } = await getContentAPIToken(endpoint, siteUrl);
+
+    // Authenticated with the docs site's own content token, not the user's credentials: the
+    // person running the CLI has no permission on the site collecting the feedback.
+    const api = new GitBookAPI({
+        userAgent: USER_AGENT,
+        endpoint,
+        authToken: token,
+    });
+
+    const response = await api.orgs.submitAgentFeedbackToSite(organization, site, {
+        reportedBy: {
+            ...(input.model ? { model: input.model } : {}),
+            userAgent: USER_AGENT,
+            ...(input.onDemand === undefined ? {} : { onDemand: input.onDemand }),
+        },
+        subject: input.command
+            ? {
+                  kind: 'cli-command',
+                  command: input.command,
+                  ...(input.flags?.length ? { flags: input.flags } : {}),
+              }
+            : { kind: 'generic' },
+        feedback: {
+            category: input.category,
+            summary: input.summary,
+            ...(input.severity ? { severity: input.severity } : {}),
+            ...(input.detail ? { detail: input.detail } : {}),
+            ...(input.goal ? { goal: input.goal } : {}),
+            ...(input.workaround ? { workaround: input.workaround } : {}),
+        },
+    } as never);
+
+    return {
+        id: response.data?.id ?? '',
+        result: response.data?.result ?? 'Thanks for your feedback.',
+    };
+}
+
+/**
+ * Build the report from a `--body` JSON object and the individual flags, with flags winning.
+ *
+ * Agents hand the whole report over as one JSON object; people reach for flags. Accepting
+ * both means neither has to learn the other's shape.
+ */
+export function resolveFeedbackInput(body: unknown, flags: Partial<FeedbackInput>): FeedbackInput {
+    if (body !== undefined && (typeof body !== 'object' || body === null || Array.isArray(body))) {
+        throw new Error('--body must be a JSON object.');
+    }
+
+    const merged = {
+        ...(body as Partial<FeedbackInput> | undefined),
+        ...stripUndefined(flags),
+    };
+
+    const missing = (['category', 'summary'] as const).filter((key) => !merged[key]);
+    if (missing.length > 0) {
+        throw new Error(
+            `Missing required field(s): ${missing.join(', ')}.\n` +
+                '  as flags: --category <category> --summary <summary>\n' +
+                `  or JSON:  --body '{"category":"usability","summary":"…"}'`,
+        );
+    }
+
+    return merged as FeedbackInput;
+}
+
+function stripUndefined<T extends object>(value: T): Partial<T> {
+    return Object.fromEntries(
+        Object.entries(value).filter(([, v]) => v !== undefined),
+    ) as Partial<T>;
+}
+
+/**
+ * The published docs site collecting feedback for an API endpoint, if any.
+ */
+export function getDocsSiteURL(endpoint: string): string | undefined {
+    try {
+        return DOCS_SITE_URL_BY_API_HOST[new URL(endpoint).host];
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Read the expiry of a content API token, which is a JWT.
+ *
+ * Only the payload is decoded, never verified: the value is used to decide when to ask for a
+ * new token, and the API is the one that rejects an expired one.
+ */
+export function getTokenExpiry(token: string): number | undefined {
+    const payload = token.split('.')[1];
+    if (!payload) {
+        return undefined;
+    }
+
+    try {
+        const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+        return typeof decoded?.exp === 'number' ? decoded.exp * 1000 : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Whether a cached token is still usable, leaving a margin before its expiry.
+ */
+export function isTokenUsable(expiresAt: number | undefined, now: number = Date.now()): boolean {
+    return typeof expiresAt === 'number' && expiresAt - EXPIRY_MARGIN_MS > now;
+}
+
+/**
+ * A content API token for the docs site, reusing the cached one until it nears expiry.
+ *
+ * The token lives about a day, so resolving is rare; it is cached because resolving on every
+ * report would be a wasted round trip, not because the call is expensive.
+ */
+async function getContentAPIToken(
+    endpoint: string,
+    siteUrl: string,
+): Promise<{ token: string; organization: string; site: string }> {
+    const env = getEnvironment();
+    const cached = config.get(`envs.${env}.feedbackToken`) as
+        | { token: string; organization: string; site: string; expiresAt?: number }
+        | undefined;
+
+    if (cached?.token && isTokenUsable(cached.expiresAt)) {
+        return {
+            token: cached.token,
+            organization: cached.organization,
+            site: cached.site,
+        };
+    }
+
+    // Resolving a published URL needs no credentials, which is what lets the CLI report
+    // feedback without the user being signed in.
+    const api = new GitBookAPI({ userAgent: USER_AGENT, endpoint });
+    const { data } = await api.urls.resolvePublishedContentByUrl({
+        url: siteUrl,
+    });
+
+    if (!('apiToken' in data) || !data.apiToken || !('site' in data) || !data.site) {
+        throw new Error(`Could not resolve the docs site at ${siteUrl} to report feedback to.`);
+    }
+
+    const resolved = {
+        token: data.apiToken,
+        organization: data.organization,
+        site: data.site,
+        expiresAt: getTokenExpiry(data.apiToken),
+    };
+    config.set(`envs.${env}.feedbackToken`, resolved);
+
+    return {
+        token: resolved.token,
+        organization: resolved.organization,
+        site: resolved.site,
+    };
+}

--- a/packages/cli/src/remote.ts
+++ b/packages/cli/src/remote.ts
@@ -2,11 +2,12 @@ import { GitBookAPI, type GitBookAPIServiceBinding } from '@gitbook/api';
 
 import { version } from '../package.json';
 import { clearAuthConfig, getAuthConfig, getStoredEnvConfig, saveAuthConfig } from './config';
+import { markUserActionable } from './errors';
 import { DEFAULT_ENV, getEnvironment } from './environments';
 import { authenticateWithBrowser, refreshOAuthSessionIfNeeded } from './oauth';
 import { type OutputOptions, printResult } from './output';
 
-const USER_AGENT = `GitBook-CLI/${version}`;
+export const USER_AGENT = `GitBook-CLI/${version}`;
 
 /**
  * Extracted from the API's 403 error message when the token is missing OAuth scopes, e.g. "This
@@ -23,8 +24,10 @@ const MISSING_SCOPES_REGEX = /missing OAuth scopes:\s*([^)]+)/i;
 export async function getAPIClient(requireAuth: boolean = true): Promise<GitBookAPI> {
     const { endpoint, token, oauth } = await resolveAuth();
     if (!token && requireAuth) {
-        throw new Error(
-            `You must be authenticated before you can run this command.\n  Run "${getLoginCommand()}" to sign in with your browser, or "${getAuthCommand()}" to use an API token.`,
+        throw markUserActionable(
+            new Error(
+                `You must be authenticated before you can run this command.\n  Run "${getLoginCommand()}" to sign in with your browser, or "${getAuthCommand()}" to use an API token.`,
+            ),
         );
     }
 

--- a/scripts/generate-commands.ts
+++ b/scripts/generate-commands.ts
@@ -93,6 +93,7 @@ interface Operation {
     description?: string;
     tags?: string[];
     security?: SecurityRequirement[];
+    'x-internal'?: boolean;
     parameters?: (ParameterObject | RefObject)[];
     requestBody?: RequestBody;
     responses?: Record<string, { content?: Record<string, unknown> }>;
@@ -162,7 +163,17 @@ const EXCLUDE = new Set([
 //   ''  → tokens that complete at the top level (the hand-written groups + auth).
 //   'x' → subcommands that complete under the hand-written group `x`.
 const HAND_WRITTEN_COMPLETIONS: Record<string, string[]> = {
-    '': ['login', 'logout', 'auth', 'whoami', 'completion', 'integration', 'openapi', 'help'],
+    '': [
+        'login',
+        'logout',
+        'auth',
+        'whoami',
+        'completion',
+        'feedback',
+        'integration',
+        'openapi',
+        'help',
+    ],
     integration: ['new', 'dev', 'publish', 'unpublish', 'tail', 'check'],
     openapi: ['publish'],
 };
@@ -612,6 +623,7 @@ function buildRoutes(spec: OpenAPISpec): Route[] {
         for (const method of HTTP_VERBS) {
             const operation = pathItem[method];
             if (!operation?.operationId) continue;
+            if (operation['x-internal']) continue;
             if (!isPublicOperation(operation, globalSecurity)) continue;
             const upper = method.toUpperCase();
             if (EXCLUDE.has(`${upper} ${apiPath}`)) continue;
@@ -674,7 +686,12 @@ function buildCommands(routes: Route[]): Command[] {
     for (const [key, group] of byKey) {
         if (group.length === 1) {
             const r = group[0];
-            commands.push({ kind: 'simple', group: r.naming.group, verb: r.naming.verb, route: r });
+            commands.push({
+                kind: 'simple',
+                group: r.naming.group,
+                verb: r.naming.verb,
+                route: r,
+            });
             continue;
         }
 
@@ -922,7 +939,9 @@ function emitCommandPreamble(
 
     for (const p of route.pathParams) {
         const desc = escapeStr(
-            `${p.description ? `${p.description} ` : ''}(path parameter — may be given positionally instead)`,
+            `${
+                p.description ? `${p.description} ` : ''
+            }(path parameter — may be given positionally instead)`,
         );
         lines.push(`${I}    .option('--${p.name} <value>', '${desc}')`);
     }
@@ -976,7 +995,9 @@ function emitCommandPreamble(
         lines.push(`${I}        const missingParams: string[] = [];`);
         for (const p of route.pathParams) {
             lines.push(
-                `${I}        if (${camelize(p.name)} === undefined) missingParams.push('${p.name}');`,
+                `${I}        if (${camelize(
+                    p.name,
+                )} === undefined) missingParams.push('${p.name}');`,
             );
         }
         lines.push(`${I}        if (missingParams.length > 0) {`);
@@ -1010,7 +1031,9 @@ function emitCommandPreamble(
             }
             for (const f of liveFlags) {
                 lines.push(
-                    `${I}        if (options.${camelize(f.name)} !== undefined) body['${f.name}'] = ${bodyFlagExpr(f)};`,
+                    `${I}        if (options.${camelize(f.name)} !== undefined) body['${
+                        f.name
+                    }'] = ${bodyFlagExpr(f)};`,
                 );
             }
             // Opt-in markdown round-trip fixups on the page-document array, after
@@ -1114,7 +1137,9 @@ function emitStreamingCommand(
     lines.push(`${I}        process.on('SIGINT', onSigint);`);
     lines.push(`${I}        try {`);
     lines.push(
-        `${I}            const events = ${target}(${callArgs.join(', ')}) as AsyncIterable<unknown>;`,
+        `${I}            const events = ${target}(${callArgs.join(
+            ', ',
+        )}) as AsyncIterable<unknown>;`,
     );
     lines.push(`${I}            for await (const event of events) {`);
     // Each event resets the idle timer, so a slow-but-live stream is never cut off.
@@ -1211,7 +1236,9 @@ function emitMergedCommand(
     lines.push(`${I}            else {`);
     lines.push(`${I}                timeout?.clear();`);
     lines.push(
-        `${I}                console.error('Specify a valid scope${noScopeNote}: ${escapeStr(flagList)}. Some scopes require a combination (e.g. --integration with --installation).');`,
+        `${I}                console.error('Specify a valid scope${noScopeNote}: ${escapeStr(
+            flagList,
+        )}. Some scopes require a combination (e.g. --integration with --installation).');`,
     );
     lines.push(`${I}                process.exit(1);`);
     lines.push(`${I}            }`);
@@ -1291,7 +1318,11 @@ function emitFile(tree: GroupNode, completions: Record<string, string>): string 
     lines.push(``);
     lines.push(`// Shell completion scripts, generated from the command tree.`);
     lines.push(
-        `export const COMPLETIONS: Record<string, string> = ${JSON.stringify(completions, null, 4)};`,
+        `export const COMPLETIONS: Record<string, string> = ${JSON.stringify(
+            completions,
+            null,
+            4,
+        )};`,
     );
     lines.push(``);
     return lines.join('\n');
@@ -1378,7 +1409,9 @@ ${bash}`;
                 : `__fish_seen_subcommand_from ${key.split(' ').join(' ')}`;
         for (const t of tokens) {
             fishLines.push(
-                `complete -c gitbook -n '${depth === 0 ? 'test (count (commandline -opc)) -eq 1' : cond}' -f -a '${t}'`,
+                `complete -c gitbook -n '${
+                    depth === 0 ? 'test (count (commandline -opc)) -eq 1' : cond
+                }' -f -a '${t}'`,
             );
         }
     }


### PR DESCRIPTION
This PR aims to add `feedback` command to GitBook CLI to allow agents report friction with the CLI, submitting to the new agent feedback API endpoint.