### PR TITLE
Only forward Osano consent to GitBook once the visitor has acted

### DIFF
--- a/.changeset/quiet-osano-banner.md
+++ b/.changeset/quiet-osano-banner.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-osano': patch
+---
+
+Stop the Osano banner from disappearing on its own. Osano saves a default consent during initialization in permissive mode, and forwarding it to GitBook reloaded the page under the banner before the visitor could respond, after which Osano never showed it again. Consent is now only forwarded once the visitor has closed the dialog or drawer.

--- a/integrations/osano/src/script.raw.js
+++ b/integrations/osano/src/script.raw.js
@@ -34,16 +34,20 @@
             setupOsanoPreload();
 
             var CONSENT_STORAGE_KEY = 'osano-gitbook-last-consent-decision';
+            var visitorActed = false;
+            var pendingDecision = null;
 
-            function emitConsent(consent) {
+            function decisionFor(consent) {
+                var hasNonEssential =
+                    !!consent &&
+                    NON_ESSENTIAL_CATEGORIES.some(function (category) {
+                        return consent[category] === 'ACCEPT';
+                    });
+                return hasNonEssential ? 'approve' : 'reject';
+            }
+
+            function forward(decision) {
                 try {
-                    var hasNonEssential =
-                        !!consent &&
-                        NON_ESSENTIAL_CATEGORIES.some(function (category) {
-                            return consent[category] === 'ACCEPT';
-                        });
-                    var decision = hasNonEssential ? 'approve' : 'reject';
-
                     // onConsentSaved replays the visitor's existing decision on every
                     // page load, not just when it changes. GitBook's onApprove/onReject
                     // can trigger a reload to reinitialize scripts, so forwarding every
@@ -53,7 +57,7 @@
                     if (w.sessionStorage.getItem(CONSENT_STORAGE_KEY) === decision) return;
                     w.sessionStorage.setItem(CONSENT_STORAGE_KEY, decision);
 
-                    if (hasNonEssential) {
+                    if (decision === 'approve') {
                         onApprove();
                     } else {
                         onReject();
@@ -63,7 +67,37 @@
                 }
             }
 
+            function emitConsent(consent) {
+                var decision = decisionFor(consent);
+
+                // In permissive mode Osano saves a default consent on its own while the
+                // banner is still up. Forwarding that reloads the page under the banner,
+                // and Osano then treats the consent as given and never shows it again.
+                // Hold the decision until the visitor has actually done something.
+                if (!visitorActed) {
+                    pendingDecision = decision;
+                    return;
+                }
+
+                forward(decision);
+            }
+
+            function onVisitorActed() {
+                visitorActed = true;
+                if (pendingDecision) {
+                    var decision = pendingDecision;
+                    pendingDecision = null;
+                    forward(decision);
+                }
+            }
+
             w.Osano('onConsentSaved', emitConsent);
+            // The dialog or drawer only closes on visitor input.
+            w.Osano('onUiChanged', function (component, state) {
+                if ((component === 'dialog' || component === 'drawer') && state === 'hide') {
+                    onVisitorActed();
+                }
+            });
 
             injectOsano();
         });


### PR DESCRIPTION
On sites using Osano, the consent banner appeared and then vanished on a fresh visit without the visitor touching it, and never came back.

**What happened, in order:**

1. Osano renders its banner.
2. In permissive mode, Osano saves a default consent on its own during init and fires `onConsentSaved`.
3. Our script forwards that as a rejection to GitBook's `onReject()`, which calls `window.location.reload()`.
4. After the reload, Osano has a stored consent, so the banner is never shown again.

Confirmed on apryse.gitbook.io from a clean profile: one navigation from me, but the page reported `navigation.type === "reload"` and our `osano-gitbook-last-consent-decision` session key was already set to `reject`.

**Fix:** hold the decision from `onConsentSaved` until Osano reports the dialog or drawer closing (`onUiChanged` → `hide`), which only happens on visitor input. Works in either event order. Same approach as the OneTrust fix in #1233.
