### PR TITLE
Bump API for permanent site redirects

### DIFF
--- a/.changeset/permanent-site-redirects.md
+++ b/.changeset/permanent-site-redirects.md
@@ -1,0 +1,6 @@
+---
+'@gitbook/api': minor
+'@gitbook/cli': patch
+---
+
+Bump API to expose the permanent flag on site redirects


### PR DESCRIPTION
Regenerates `@gitbook/api` so `SiteRedirect.permanent` is available to clients.

Consumer: GitbookIO/gitbook#4589.