### PR TITLE
Ignore consent Osano saves on its own during initialization

### DIFF
--- a/.changeset/osano-init-consent.md
+++ b/.changeset/osano-init-consent.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-osano': patch
+---
+
+Keep the Osano banner on screen on informational (timer) banners. Osano auto-accepts, saves and fires a dialog hide during initialization on those, which the integration mistook for a visitor decision and reloaded the page under the banner. Only consent saved after Osano reports initialized is forwarded to GitBook now.

--- a/integrations/osano/src/script.raw.js
+++ b/integrations/osano/src/script.raw.js
@@ -34,30 +34,30 @@
             setupOsanoPreload();
 
             var CONSENT_STORAGE_KEY = 'osano-gitbook-last-consent-decision';
-            var visitorActed = false;
-            var pendingDecision = null;
+            var initialized = false;
 
-            function decisionFor(consent) {
-                var hasNonEssential =
-                    !!consent &&
-                    NON_ESSENTIAL_CATEGORIES.some(function (category) {
-                        return consent[category] === 'ACCEPT';
-                    });
-                return hasNonEssential ? 'approve' : 'reject';
-            }
+            function emitConsent(consent) {
+                // Everything Osano saves before it reports itself initialized is its own doing:
+                // the auto-accept on informational (timer) banners, or a returning visitor's
+                // replayed decision. Forwarding those reloaded the page under the banner.
+                if (!initialized) return;
 
-            function forward(decision) {
                 try {
-                    // onConsentSaved replays the visitor's existing decision on every
-                    // page load, not just when it changes. GitBook's onApprove/onReject
-                    // can trigger a reload to reinitialize scripts, so forwarding every
-                    // replay would reload -> replay -> reload forever. Only forward the
-                    // decision when it's actually different from last time, and persist
-                    // that in sessionStorage since it must survive the reload.
+                    var hasNonEssential =
+                        !!consent &&
+                        NON_ESSENTIAL_CATEGORIES.some(function (category) {
+                            return consent[category] === 'ACCEPT';
+                        });
+                    var decision = hasNonEssential ? 'approve' : 'reject';
+
+                    // GitBook's onApprove/onReject reload to reinitialize scripts, so only
+                    // forward a decision GitBook doesn't already hold. The sessionStorage
+                    // copy must survive that reload.
+                    if (w.GitBook.isCookiesTrackingDisabled() === !hasNonEssential) return;
                     if (w.sessionStorage.getItem(CONSENT_STORAGE_KEY) === decision) return;
                     w.sessionStorage.setItem(CONSENT_STORAGE_KEY, decision);
 
-                    if (decision === 'approve') {
+                    if (hasNonEssential) {
                         onApprove();
                     } else {
                         onReject();
@@ -67,37 +67,10 @@
                 }
             }
 
-            function emitConsent(consent) {
-                var decision = decisionFor(consent);
-
-                // In permissive mode Osano saves a default consent on its own while the
-                // banner is still up. Forwarding that reloads the page under the banner,
-                // and Osano then treats the consent as given and never shows it again.
-                // Hold the decision until the visitor has actually done something.
-                if (!visitorActed) {
-                    pendingDecision = decision;
-                    return;
-                }
-
-                forward(decision);
-            }
-
-            function onVisitorActed() {
-                visitorActed = true;
-                if (pendingDecision) {
-                    var decision = pendingDecision;
-                    pendingDecision = null;
-                    forward(decision);
-                }
-            }
-
-            w.Osano('onConsentSaved', emitConsent);
-            // The dialog or drawer only closes on visitor input.
-            w.Osano('onUiChanged', function (component, state) {
-                if ((component === 'dialog' || component === 'drawer') && state === 'hide') {
-                    onVisitorActed();
-                }
+            w.Osano('onInitialized', function () {
+                initialized = true;
             });
+            w.Osano('onConsentSaved', emitConsent);
 
             injectOsano();
         });

--- a/integrations/osano/src/script.raw.js
+++ b/integrations/osano/src/script.raw.js
@@ -37,9 +37,7 @@
             var initialized = false;
 
             function emitConsent(consent) {
-                // Everything Osano saves before it reports itself initialized is its own doing:
-                // the auto-accept on informational (timer) banners, or a returning visitor's
-                // replayed decision. Forwarding those reloaded the page under the banner.
+                // Consent saved before Osano is initialized is Osano's own, not the visitor's.
                 if (!initialized) return;
 
                 try {
@@ -50,9 +48,7 @@
                         });
                     var decision = hasNonEssential ? 'approve' : 'reject';
 
-                    // GitBook's onApprove/onReject reload to reinitialize scripts, so only
-                    // forward a decision GitBook doesn't already hold. The sessionStorage
-                    // copy must survive that reload.
+                    // onApprove/onReject reload the page, so skip decisions GitBook already holds.
                     if (w.GitBook.isCookiesTrackingDisabled() === !hasNonEssential) return;
                     if (w.sessionStorage.getItem(CONSENT_STORAGE_KEY) === decision) return;
                     w.sessionStorage.setItem(CONSENT_STORAGE_KEY, decision);


### PR DESCRIPTION
Follow-up to #1291. On Osano's informational banner (template one, what Apryse's region gets), Osano auto-accepts and fires a dialog `hide` during init, before the dialog has even shown. We took that as a visitor decision, called `onApprove()`, and reloaded the page under the banner.

Fix: only forward consent saved after `onInitialized`. Drop the `hide` listener.

Tested on apryse.gitbook.io by forcing each template: one now stays open with no reload; three (Accept) and two (Reject) still forward and reload.

Fixes RND-12687.
