### PR TITLE
Allow forcing an Osano banner template

### DIFF
--- a/.changeset/osano-variant.md
+++ b/.changeset/osano-variant.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/integration-osano': minor
+---
+
+Add an optional "Banner template" setting to force one Osano banner template (one, two, three or six) for every visitor instead of Osano's region-based choice.

--- a/integrations/osano/gitbook-manifest.yaml
+++ b/integrations/osano/gitbook-manifest.yaml
@@ -41,6 +41,15 @@ configurations:
                 type: string
                 title: Configuration ID
                 description: The Osano Configuration ID, the second ID segment in your osano.js script URL
+            variant:
+                type: string
+                title: Banner template
+                description: Force one banner template for all visitors. Leave empty to let Osano pick by region.
+                enum:
+                    - one
+                    - two
+                    - three
+                    - six
         required:
             - customer_id
             - config_id

--- a/integrations/osano/src/index.ts
+++ b/integrations/osano/src/index.ts
@@ -13,6 +13,7 @@ type OsanoRuntimeContext = RuntimeContext<
         {
             customer_id?: string;
             config_id?: string;
+            variant?: string;
         }
     >
 >;
@@ -23,13 +24,17 @@ export const handleFetchEvent: FetchPublishScriptEventCallback = async (
 ) => {
     const customerId = environment.siteInstallation?.configuration?.customer_id;
     const configId = environment.siteInstallation?.configuration?.config_id;
+    const variant = environment.siteInstallation?.configuration?.variant;
 
     if (!customerId || !configId) {
         return;
     }
 
     return new Response(
-        (script as string).replace('<CUSTOMER_ID>', customerId).replace('<CONFIG_ID>', configId),
+        (script as string)
+            .replace('<CUSTOMER_ID>', customerId)
+            .replace('<CONFIG_ID>', configId)
+            .replace('<VARIANT_QUERY>', variant ? `?variant=${encodeURIComponent(variant)}` : ''),
         {
             headers: {
                 'Content-Type': 'application/javascript',

--- a/integrations/osano/src/script.raw.js
+++ b/integrations/osano/src/script.raw.js
@@ -23,7 +23,7 @@
         s.id = 'osano-sdk-stub';
         s.type = 'text/javascript';
         s.async = true;
-        s.src = 'https://cmp.osano.com/<CUSTOMER_ID>/<CONFIG_ID>/osano.js';
+        s.src = 'https://cmp.osano.com/<CUSTOMER_ID>/<CONFIG_ID>/osano.js<VARIANT_QUERY>';
         d.head.appendChild(s);
     }
 


### PR DESCRIPTION
Adds an optional "Banner template" setting to the Osano integration, appended to the osano.js URL as ?variant=one|two|three|six.

Osano picks a banner template per visitor region. Apryse's region gets the informational one, which self-dismisses on a 10s timer; docs.apryse.com avoids that by forcing variant=two through GTM. This lets them do the same on GitBook.

Empty (the default) keeps Osano's region-based choice. Forcing a template applies to every visitor and overrides Osano's compliance logic